### PR TITLE
Implement simple issurance, transfer and burn

### DIFF
--- a/lib/glueby.rb
+++ b/lib/glueby.rb
@@ -3,6 +3,7 @@ require 'tapyrus'
 
 module Glueby
   autoload :Contract, 'glueby/contract'
+  autoload :Wallet, 'glueby/wallet'
   autoload :Internal, 'glueby/internal'
 
   begin

--- a/lib/glueby/contract.rb
+++ b/lib/glueby/contract.rb
@@ -4,8 +4,10 @@ module Glueby
     autoload :FeeProvider, 'glueby/contract/fee_provider'
     autoload :FixedFeeProvider, 'glueby/contract/fee_provider'
     autoload :Timestamp, 'glueby/contract/timestamp'
+    autoload :Token, 'glueby/contract/token'
+    autoload :TokenTxBuilder, 'glueby/contract/token_tx_builder'
     autoload :TxBuilder, 'glueby/contract/tx_builder'
-    autoload :WalletFeature, 'glueby/contract/wallet_feature'
     autoload :AR, 'glueby/contract/active_record'
+    autoload :Wallet, 'glueby/contract/wallet'
   end
 end

--- a/lib/glueby/contract/errors.rb
+++ b/lib/glueby/contract/errors.rb
@@ -7,6 +7,7 @@ module Glueby
       class InvalidTokenType < StandardError; end
       class TxAlreadyBroadcasted < StandardError; end
       class UnsupportedTokenType < StandardError; end
+      class UnknownScriptPubkey < StandardError; end
     end
   end
 end

--- a/lib/glueby/contract/errors.rb
+++ b/lib/glueby/contract/errors.rb
@@ -2,7 +2,11 @@ module Glueby
   module Contract
     module Errors
       class InsufficientFunds < StandardError; end
+      class InsufficientTokens < StandardError; end
+      class InvalidAmount < StandardError; end
+      class InvalidTokenType < StandardError; end
       class TxAlreadyBroadcasted < StandardError; end
+      class UnsupportedTokenType < StandardError; end
     end
   end
 end

--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -152,8 +152,7 @@ module Glueby
         # collect utxo associated with this address
         utxos = wallet.list_unspent
         _, results = collect_colored_outputs(utxos, color_id)
-        # sum amount in the utxos
-        results.inject(0) { |sum, result| sum + result[:amount] }
+        results.sum { |result| result[:amount] }
       end
 
       # Return color id

--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -41,7 +41,6 @@ module Glueby
     class Token
       include Glueby::Contract::TokenTxBuilder
       extend Glueby::Contract::TokenTxBuilder
-      using Glueby::Wallet::InternalWallet
 
       class << self
         # Issue new token with specified amount and token type.
@@ -150,7 +149,7 @@ module Glueby
       # @return [Integer] amount of utxo value associated with this token.
       def amount(wallet:)
         # collect utxo associated with this address
-        utxos = wallet.list_unspent
+        utxos = wallet.internal_wallet.list_unspent
         _, results = collect_colored_outputs(utxos, color_id)
         results.sum { |result| result[:amount] }
       end

--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+module Glueby
+  module Contract
+    # This class represents custom token issued by application user.
+    # Application users can
+    # - issue their own tokens.
+    # - send to other users.
+    # - make the tokens disable.
+    #
+    # Examples:
+    #
+    # alice = Glueby::Wallet.create
+    # bob = Glueby::Wallet.create
+    #
+    # Issue
+    # token = Token.issue!(issuer: alice, amount: 100)
+    # token.amount(wallet: alice)
+    # => 100
+    #
+    # Send
+    # token.transfer!(sender: alice, receiver: bob, amount: 1)
+    # token.amount(wallet: alice)
+    # => 99
+    # token.amount(wallet: bob)
+    # => 1
+    #
+    # Burn
+    # token.burn!(sender: alice, amount: 10)
+    # token.amount(wallet: alice)
+    # => 89
+    # token.burn!(sender: alice)
+    # token.amount(wallet: alice)
+    # => 0
+    #
+    # Reissue
+    # token.reissue!(issuer: alice, amount: 100)
+    # token.amount(wallet: alice)
+    # => 100
+    #
+    class Token
+      include Glueby::Contract::TokenTxBuilder
+      extend Glueby::Contract::TokenTxBuilder
+      using Glueby::Wallet::InternalWallet
+
+      class << self
+        # Issue new token with specified amount and token type.
+        # REISSUABLE token can be reissued with #reissue! method, and
+        # NON_REISSUABLE and NFT token can not.
+        # Amount is set to 1 when the token type is NFT
+        #
+        # @param issuer [Glueby::Wallet]
+        # @param token_type [TokenTypes]
+        # @param amount [Integer]
+        # @return [Token] token
+        # @raise [InsufficientFunds] if wallet does not have enough TPC to send transaction.
+        # @raise [InvalidAmount] if amount is not positive integer.
+        # @raise [UnspportedTokenType] if token is not supported.
+        def issue!(issuer:, token_type: Tapyrus::Color::TokenTypes::REISSUABLE, amount: 1)
+          raise Glueby::Contract::Errors::InvalidAmount unless amount.positive?
+
+          txs, payload = case token_type
+                         when Tapyrus::Color::TokenTypes::REISSUABLE
+                           issue_reissuable_token(issuer: issuer, amount: amount)
+                         when Tapyrus::Color::TokenTypes::NON_REISSUABLE
+                           issue_non_reissuable_token(issuer: issuer, amount: amount)
+                         when Tapyrus::Color::TokenTypes::NFT
+                           issue_nft_token(issuer: issuer)
+                         else
+                           raise Glueby::Contract::Errors::UnsupportedTokenType
+                         end
+          txs.each { |tx| Glueby::Internal::RPC.client.sendrawtransaction(tx.to_payload.bth) }
+          new(token_type: token_type, payload: payload)
+        end
+
+        private
+
+        def issue_reissuable_token(issuer:, amount:)
+          estimated_fee = 20_000
+          funding_tx = create_funding_tx(wallet: issuer, amount: estimated_fee)
+          tx = create_issue_tx_for_reissuable_token(funding_tx: funding_tx, issuer: issuer, amount: amount)
+          payload = funding_tx.outputs.first.script_pubkey.to_payload
+          [[funding_tx, tx], payload]
+        end
+
+        def issue_non_reissuable_token(issuer:, amount:)
+          tx = create_issue_tx_for_non_reissuable_token(issuer: issuer, amount: amount)
+          payload = tx.inputs.first.out_point.to_payload
+          [[tx], payload]
+        end
+
+        def issue_nft_token(issuer:)
+          tx = create_issue_tx_for_nft_token(issuer: issuer)
+          payload = tx.inputs.first.out_point.to_payload
+          [[tx], payload]
+        end
+      end
+
+      # Re-issue the token with specified amount.
+      # A wallet can issue the token only when it is REISSUABLE token.
+      # @param issuer [Glueby::Wallet]
+      # @param amount [Integer]
+      # @raise [InsufficientFunds] if wallet does not have enough TPC to send transaction.
+      # @raise [InvalidAmount] if amount is not positive integer.
+      # @raise [InvalidTokenType] if token is not reissuable.
+      def reissue!(issuer:, amount:)
+        raise Glueby::Contract::Errors::InvalidAmount unless amount.positive?
+        raise Glueby::Contract::Errors::InvalidTokenType unless token_type == Tapyrus::Color::TokenTypes::REISSUABLE
+
+        funding_script = Tapyrus::Script.parse_from_payload(@payload)
+        txs = create_reissue_tx(issuer: issuer, amount: amount, funding_script: funding_script, color_id: color_id)
+        txs.each { |tx| Glueby::Internal::RPC.client.sendrawtransaction(tx.to_payload.bth) }
+      end
+
+      # Send the token to other wallet
+      #
+      # @param sender [Glueby::Wallet] wallet to send this token
+      # @param receiver [Glueby::Wallet] wallet to receive this token
+      # @param amount [Integer]
+      # @return [Token] receiver token
+      # @raise [InsufficientFunds] if wallet does not have enough TPC to send transaction.
+      # @raise [InsufficientTokens] if wallet does not have enough token to send.
+      # @raise [InvalidAmount] if amount is not positive integer.
+      def transfer!(sender:, receiver:, amount: 1)
+        raise Glueby::Contract::Errors::InvalidAmount unless amount.positive?
+
+        tx = create_transfer_tx(color_id: color_id, sender: sender, receiver: receiver, amount: amount)
+        Glueby::Internal::RPC.client.sendrawtransaction(tx.to_payload.bth)
+      end
+
+      # Burn token
+      # If amount is not specified or 0, burn all token associated with the wallet.
+      #
+      # @param sender [Glueby::Wallet] wallet to send this token
+      # @param amount [Integer]
+      # @raise [InsufficientFunds] if wallet does not have enough TPC to send transaction.
+      # @raise [InsufficientTokens] if wallet does not have enough token to send transaction.
+      # @raise [InvalidAmount] if amount is not positive integer.
+      def burn!(sender:, amount: 0)
+        raise Glueby::Contract::Errors::InvalidAmount unless amount.positive?
+
+        tx = create_burn_tx(color_id: color_id, sender: sender, amount: amount)
+        Glueby::Internal::RPC.client.sendrawtransaction(tx.to_payload.bth)
+      end
+
+      # Return balance of token in the specified wallet.
+      # @param wallet [Glueby::Wallet]
+      # @return [Integer] amount of utxo value associated with this token.
+      def amount(wallet:)
+        # collect utxo associated with this address
+        utxos = wallet.list_unspent
+        _, results = collect_colored_outputs(utxos, color_id)
+        # sum amount in the utxos
+        results.inject(0) { |sum, result| sum + result[:amount] }
+      end
+
+      # Return color id
+      # @return [Tapyrus::Color::ColorIdentifier]
+      def color_id
+        Tapyrus::Color::ColorIdentifier.parse_from_payload([@token_type, Tapyrus.sha256(@payload)].pack('Ca*'))
+      end
+
+      # Return token type
+      # @return [Tapyrus::Color::TokenTypes]
+      def token_type
+        color_id.type
+      end
+
+      # Return serialized payload
+      # @return [String] payload
+      def to_payload
+        [@token_type, @payload].pack('Ca*')
+      end
+
+      # Restore token from payload
+      # @param payload [String]
+      # @return [Glueby::Contract::Token]
+      def self.parse_from_payload(payload)
+        token_type, payload = payload.unpack('Ca*')
+        new(token_type: token_type, payload: payload)
+      end
+
+      private
+
+      def initialize(token_type: Tapyrus::Color::TokenTypes::REISSUABLE, payload:)
+        @token_type = token_type
+        @payload = payload
+      end
+    end
+  end
+end

--- a/lib/glueby/contract/token_tx_builder.rb
+++ b/lib/glueby/contract/token_tx_builder.rb
@@ -31,7 +31,7 @@ module Glueby
         tx.inputs << Tapyrus::TxIn.new(out_point: out_point)
         output = funding_tx.outputs.first
 
-        receiver_script = Tapyrus::Script.parse_from_addr(issuer.internal_wallet.receive_address)
+        receiver_script = Tapyrus::Script.parse_from_payload(output.script_pubkey.to_payload)
         color_id = Tapyrus::Color::ColorIdentifier.reissuable(receiver_script)
         receiver_colored_script = receiver_script.add_color(color_id)
         tx.outputs << Tapyrus::TxOut.new(value: amount, script_pubkey: receiver_colored_script)
@@ -92,7 +92,7 @@ module Glueby
         tx.inputs << Tapyrus::TxIn.new(out_point: out_point)
         output = funding_tx.outputs.first
 
-        receiver_script = Tapyrus::Script.parse_from_addr(issuer.internal_wallet.receive_address)
+        receiver_script = Tapyrus::Script.parse_from_payload(output.script_pubkey.to_payload)
         receiver_colored_script = receiver_script.add_color(color_id)
         tx.outputs << Tapyrus::TxOut.new(value: amount, script_pubkey: receiver_colored_script)
 

--- a/lib/glueby/contract/token_tx_builder.rb
+++ b/lib/glueby/contract/token_tx_builder.rb
@@ -10,7 +10,7 @@ module Glueby
       # Create new public key, and new transaction that sends TPC to it
       def create_funding_tx(wallet:, amount:, script: nil, fee_provider: FixedFeeProvider.new)
         tx = Tapyrus::Tx.new
-        fee = fee_provider.fee(tx)
+        fee = fee_provider.fee(dummy_tx(tx))
 
         utxos = wallet.internal_wallet.list_unspent
         sum, outputs = collect_uncolored_outputs(utxos, fee + amount)
@@ -25,7 +25,6 @@ module Glueby
 
       def create_issue_tx_for_reissuable_token(funding_tx:, issuer:, amount:, fee_provider: FixedFeeProvider.new)
         tx = Tapyrus::Tx.new
-        fee = fee_provider.fee(tx)
 
         out_point = Tapyrus::OutPoint.from_txid(funding_tx.txid, 0)
         tx.inputs << Tapyrus::TxIn.new(out_point: out_point)
@@ -36,6 +35,7 @@ module Glueby
         receiver_colored_script = receiver_script.add_color(color_id)
         tx.outputs << Tapyrus::TxOut.new(value: amount, script_pubkey: receiver_colored_script)
 
+        fee = fee_provider.fee(dummy_tx(tx))
         fill_change_tpc(tx, issuer, output.value - fee)
         prev_txs = [{
           txid: funding_tx.txid,
@@ -56,8 +56,8 @@ module Glueby
 
       def create_issue_tx_from_out_point(token_type:, issuer:, amount:, fee_provider: FixedFeeProvider.new)
         tx = Tapyrus::Tx.new
-        fee = fee_provider.fee(tx)
 
+        fee = fee_provider.fee(dummy_issue_tx_from_out_point)
         utxos = issuer.internal_wallet.list_unspent
         sum, outputs = collect_uncolored_outputs(utxos, fee)
         fill_input(tx, outputs)
@@ -82,7 +82,6 @@ module Glueby
 
       def create_reissue_tx(funding_tx:, issuer:, amount:, color_id:, fee_provider: FixedFeeProvider.new)
         tx = Tapyrus::Tx.new
-        fee = fee_provider.fee(tx)
 
         out_point = Tapyrus::OutPoint.from_txid(funding_tx.txid, 0)
         tx.inputs << Tapyrus::TxIn.new(out_point: out_point)
@@ -92,6 +91,7 @@ module Glueby
         receiver_colored_script = receiver_script.add_color(color_id)
         tx.outputs << Tapyrus::TxOut.new(value: amount, script_pubkey: receiver_colored_script)
 
+        fee = fee_provider.fee(dummy_tx(tx))
         fill_change_tpc(tx, issuer, output.value - fee)
         prev_txs = [{
           txid: funding_tx.txid,
@@ -104,12 +104,8 @@ module Glueby
 
       def create_transfer_tx(color_id:, sender:, receiver:, amount:, fee_provider: FixedFeeProvider.new)
         tx = Tapyrus::Tx.new
-        fee = fee_provider.fee(tx)
 
         utxos = sender.internal_wallet.list_unspent
-        sum_tpc, outputs = collect_uncolored_outputs(utxos, fee)
-        fill_input(tx, outputs)
-
         sum_token, outputs = collect_colored_outputs(utxos, color_id, amount)
         fill_input(tx, outputs)
 
@@ -118,23 +114,29 @@ module Glueby
         tx.outputs << Tapyrus::TxOut.new(value: amount, script_pubkey: receiver_colored_script)
 
         fill_change_token(tx, sender, sum_token - amount, color_id)
+
+        fee = fee_provider.fee(dummy_tx(tx))
+        sum_tpc, outputs = collect_uncolored_outputs(utxos, fee)
+        fill_input(tx, outputs)
+
         fill_change_tpc(tx, sender, sum_tpc - fee)
         sender.internal_wallet.sign_tx(tx)
       end
 
       def create_burn_tx(color_id:, sender:, amount: 0, fee_provider: FixedFeeProvider.new)
         tx = Tapyrus::Tx.new
-        fee = fee_provider.fee(tx)
 
         utxos = sender.internal_wallet.list_unspent
-        dust = 600 # in case that the wallet has output which has just fee amount.
-        sum_tpc, outputs = collect_uncolored_outputs(utxos, fee + dust)
-        fill_input(tx, outputs)
-
         sum_token, outputs = collect_colored_outputs(utxos, color_id, amount)
         fill_input(tx, outputs)
 
         fill_change_token(tx, sender, sum_token - amount, color_id) if amount.positive?
+
+        fee = fee_provider.fee(dummy_tx(tx))
+
+        dust = 600 # in case that the wallet has output which has just fee amount.
+        sum_tpc, outputs = collect_uncolored_outputs(utxos, fee + dust)
+        fill_input(tx, outputs)
 
         fill_change_tpc(tx, sender, sum_tpc - fee)
         sender.internal_wallet.sign_tx(tx)
@@ -193,6 +195,33 @@ module Glueby
         raise Glueby::Contract::Errors::InsufficientTokens if amount.positive?
 
         results
+      end
+
+      # Add dummy inputs and outputs to tx
+      def dummy_tx(tx)
+        dummy = Tapyrus::Tx.parse_from_payload(tx.to_payload)
+
+        # dummy input for tpc
+        out_point = Tapyrus::OutPoint.new('00' * 32, 0)
+        dummy.inputs << Tapyrus::TxIn.new(out_point: out_point)
+
+        # Add script_sig to all intpus
+        dummy.inputs.each do |input|
+          input.script_sig = Tapyrus::Script.parse_from_payload('000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'.htb)
+        end
+
+        # dummy output to return change
+        change_script = Tapyrus::Script.to_p2pkh('0000000000000000000000000000000000000000')
+        dummy.outputs << Tapyrus::TxOut.new(value: 0, script_pubkey: change_script)
+        dummy
+      end
+
+      # Add dummy inputs and outputs to tx for issue non-reissuable transaction and nft transaction
+      def dummy_issue_tx_from_out_point
+        tx = Tapyrus::Tx.new
+        receiver_colored_script = Tapyrus::Script.parse_from_payload('21c20000000000000000000000000000000000000000000000000000000000000000bc76a914000000000000000000000000000000000000000088ac'.htb)
+        tx.outputs << Tapyrus::TxOut.new(value: 0, script_pubkey: receiver_colored_script)
+        dummy_tx(tx)
       end
     end
   end

--- a/lib/glueby/contract/token_tx_builder.rb
+++ b/lib/glueby/contract/token_tx_builder.rb
@@ -179,6 +179,11 @@ module Glueby
         raise Glueby::Contract::Errors::InsufficientFunds
       end
 
+      # Returns the set of utxos that satisfies the specified amount and has the specified color_id.
+      # if amount is not specified or 0, return all utxos with color_id
+      # @param results [Array] response of Glueby::Internal::Wallet#list_unspent
+      # @param color_id [Tapyrus::Color::ColorIdentifier] color identifier
+      # @param amount [Integer]
       def collect_colored_outputs(results, color_id, amount = 0)
         results = results.inject([0, []]) do |sum, output|
           next sum unless output[:color_id] == color_id.to_hex

--- a/lib/glueby/contract/token_tx_builder.rb
+++ b/lib/glueby/contract/token_tx_builder.rb
@@ -168,8 +168,7 @@ module Glueby
 
       def collect_uncolored_outputs(results, amount)
         results.inject([0, []]) do |sum, output|
-          script = Tapyrus::Script.parse_from_payload(output[:script_pubkey].htb)
-          next sum if script.cp2pkh? || script.cp2sh?
+          next sum if output[:color_id]
 
           new_sum = sum[0] + output[:amount]
           new_outputs = sum[1] << output
@@ -182,9 +181,7 @@ module Glueby
 
       def collect_colored_outputs(results, color_id, amount = 0)
         results = results.inject([0, []]) do |sum, output|
-          script = Tapyrus::Script.parse_from_payload(output[:script_pubkey].htb)
-          next sum unless script.cp2pkh? || script.cp2sh?
-          next sum unless Tapyrus::Color::ColorIdentifier.parse_from_payload(script.chunks[0].pushed_data) == color_id
+          next sum unless output[:color_id] == color_id.to_hex
 
           new_sum = sum[0] + output[:amount]
           new_outputs = sum[1] << output

--- a/lib/glueby/contract/token_tx_builder.rb
+++ b/lib/glueby/contract/token_tx_builder.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+module Glueby
+  module Contract
+    module TokenTxBuilder
+      using Glueby::Wallet::InternalWallet
+
+      def receive_address(wallet:)
+        wallet.receive_address
+      end
+
+      # Create new public key, and new transaction that sends TPC to it
+      def create_funding_tx(wallet:, amount:, fee_provider: FixedFeeProvider.new)
+        tx = Tapyrus::Tx.new
+        fee = fee_provider.fee(tx)
+
+        utxos = wallet.list_unspent
+        sum, outputs = collect_uncolored_outputs(utxos, fee + amount)
+        fill_input(tx, outputs)
+
+        receive_script = Tapyrus::Script.parse_from_addr(wallet.receive_address)
+        tx.outputs << Tapyrus::TxOut.new(value: amount, script_pubkey: receive_script)
+
+        fill_change_tpc(tx, wallet, sum - amount - fee)
+        wallet.sign_tx(tx)
+      end
+
+      def create_issue_tx_for_reissuable_token(funding_tx:, issuer:, amount:, fee_provider: FixedFeeProvider.new)
+        tx = Tapyrus::Tx.new
+        fee = fee_provider.fee(tx)
+
+        out_point = Tapyrus::OutPoint.from_txid(funding_tx.txid, 0)
+        tx.inputs << Tapyrus::TxIn.new(out_point: out_point)
+        output = funding_tx.outputs.first
+
+        receiver_script = Tapyrus::Script.parse_from_payload(output.script_pubkey.to_payload)
+        color_id = Tapyrus::Color::ColorIdentifier.reissuable(receiver_script)
+        receiver_colored_script = receiver_script.add_color(color_id)
+        tx.outputs << Tapyrus::TxOut.new(value: amount, script_pubkey: receiver_colored_script)
+
+        fill_change_tpc(tx, issuer, output.value - fee)
+        prev_txs = [{
+          txid: funding_tx.txid,
+          vout: 0,
+          scriptPubKey: output.script_pubkey.to_hex,
+          amount: output.value
+        }]
+        signed = issuer.sign_tx(tx, prev_txs)
+        signed
+      end
+
+      def create_issue_tx_for_non_reissuable_token(issuer:, amount:, fee_provider: FixedFeeProvider.new)
+        tx = Tapyrus::Tx.new
+        fee = fee_provider.fee(tx)
+
+        utxos = issuer.list_unspent
+        sum, outputs = collect_uncolored_outputs(utxos, fee)
+        fill_input(tx, outputs)
+
+        out_point = tx.inputs.first.out_point
+        color_id = Tapyrus::Color::ColorIdentifier.non_reissuable(out_point)
+
+        receiver_script = Tapyrus::Script.parse_from_addr(issuer.receive_address)
+        receiver_colored_script = receiver_script.add_color(color_id)
+        tx.outputs << Tapyrus::TxOut.new(value: amount, script_pubkey: receiver_colored_script)
+
+        fill_change_tpc(tx, issuer, sum - fee)
+        issuer.sign_tx(tx)
+      end
+
+      def create_issue_tx_for_nft_token(issuer:, fee_provider: FixedFeeProvider.new)
+        tx = Tapyrus::Tx.new
+        fee = fee_provider.fee(tx)
+
+        utxos = issuer.list_unspent
+        sum, outputs = collect_uncolored_outputs(utxos, fee)
+        fill_input(tx, outputs)
+
+        out_point = tx.inputs.first.out_point
+        color_id = Tapyrus::Color::ColorIdentifier.nft(out_point)
+
+        receiver_script = Tapyrus::Script.parse_from_addr(issuer.receive_address)
+        receiver_colored_script = receiver_script.add_color(color_id)
+        tx.outputs << Tapyrus::TxOut.new(value: 1, script_pubkey: receiver_colored_script)
+
+        fill_change_tpc(tx, issuer, sum - fee)
+        issuer.sign_tx(tx)
+      end
+
+      def create_reissue_tx(issuer:, amount:, funding_script:, color_id:, fee_provider: FixedFeeProvider.new)
+        funding_tx = Tapyrus::Tx.new
+        fee = fee_provider.fee(funding_tx)
+
+        utxos = issuer.list_unspent
+        sum, outputs = collect_uncolored_outputs(utxos, fee + amount)
+        fill_input(funding_tx, outputs)
+
+        funding_tx.outputs << Tapyrus::TxOut.new(value: amount, script_pubkey: funding_script)
+
+        fill_change_tpc(funding_tx, issuer, sum - amount - fee)
+        funding_tx = issuer.sign_tx(funding_tx)
+
+        tx = Tapyrus::Tx.new
+        fee = fee_provider.fee(tx)
+
+        out_point = Tapyrus::OutPoint.from_txid(funding_tx.txid, 0)
+        tx.inputs << Tapyrus::TxIn.new(out_point: out_point)
+        output = funding_tx.outputs.first
+
+        receiver_script = Tapyrus::Script.parse_from_payload(output.script_pubkey.to_payload)
+        receiver_colored_script = receiver_script.add_color(color_id)
+        tx.outputs << Tapyrus::TxOut.new(value: amount, script_pubkey: receiver_colored_script)
+
+        fill_change_tpc(tx, issuer, output.value - fee)
+        issuer.sign_tx(tx)
+        [funding_tx, tx]
+      end
+
+      def create_transfer_tx(color_id:, sender:, receiver:, amount:, fee_provider: FixedFeeProvider.new)
+        tx = Tapyrus::Tx.new
+        fee = fee_provider.fee(tx)
+
+        utxos = sender.list_unspent
+        sum_tpc, outputs = collect_uncolored_outputs(utxos, fee)
+        fill_input(tx, outputs)
+
+        sum_token, outputs = collect_colored_outputs(utxos, color_id, amount)
+        fill_input(tx, outputs)
+
+        receiver_script = Tapyrus::Script.parse_from_addr(receiver.receive_address)
+        receiver_colored_script = receiver_script.add_color(color_id)
+        tx.outputs << Tapyrus::TxOut.new(value: amount, script_pubkey: receiver_colored_script)
+
+        fill_change_token(tx, sender, sum_token - amount, color_id)
+        fill_change_tpc(tx, sender, sum_tpc - fee)
+        sender.sign_tx(tx)
+      end
+
+      def create_burn_tx(color_id:, sender:, amount: 0, fee_provider: FixedFeeProvider.new)
+        tx = Tapyrus::Tx.new
+        fee = fee_provider.fee(tx)
+
+        utxos = sender.list_unspent
+        dust = 600 # in case that the wallet has output which has just fee amount.
+        sum_tpc, outputs = collect_uncolored_outputs(utxos, fee + dust)
+        fill_input(tx, outputs)
+
+        sum_token, outputs = collect_colored_outputs(utxos, color_id, amount)
+        fill_input(tx, outputs)
+
+        fill_change_token(tx, sender, sum_token - amount, color_id) if amount.positive?
+
+        fill_change_tpc(tx, sender, sum_tpc - fee)
+        sender.sign_tx(tx)
+      end
+
+      def fill_input(tx, outputs)
+        outputs.each do |output|
+          out_point = Tapyrus::OutPoint.new(output[:txid].rhex, output[:vout])
+          tx.inputs << Tapyrus::TxIn.new(out_point: out_point)
+        end
+      end
+
+      def fill_change_tpc(tx, wallet, change)
+        return unless change.positive?
+
+        change_script = Tapyrus::Script.parse_from_addr(wallet.change_address)
+        tx.outputs << Tapyrus::TxOut.new(value: change, script_pubkey: change_script)
+      end
+
+      def fill_change_token(tx, wallet, change, color_id)
+        return unless change.positive?
+
+        change_script = Tapyrus::Script.parse_from_addr(wallet.change_address)
+        change_colored_script = change_script.add_color(color_id)
+        tx.outputs << Tapyrus::TxOut.new(value: change, script_pubkey: change_colored_script)
+      end
+
+      def collect_uncolored_outputs(results, amount)
+        results.inject([0, []]) do |sum, output|
+          script = Tapyrus::Script.parse_from_payload(output[:script_pubkey].htb)
+          next sum if script.cp2pkh? || script.cp2sh?
+
+          new_sum = sum[0] + output[:amount]
+          new_outputs = sum[1] << output
+          return [new_sum, new_outputs] if new_sum >= amount
+
+          [new_sum, new_outputs]
+        end
+        raise Glueby::Contract::Errors::InsufficientFunds
+      end
+
+      def collect_colored_outputs(results, color_id, amount = 0)
+        results = results.inject([0, []]) do |sum, output|
+          script = Tapyrus::Script.parse_from_payload(output[:script_pubkey].htb)
+          next sum unless script.cp2pkh? || script.cp2sh?
+          next sum unless Tapyrus::Color::ColorIdentifier.parse_from_payload(script.chunks[0].pushed_data) == color_id
+
+          new_sum = sum[0] + output[:amount]
+          new_outputs = sum[1] << output
+          return [new_sum, new_outputs] if new_sum >= amount && amount.positive?
+
+          [new_sum, new_outputs]
+        end
+        raise Glueby::Contract::Errors::InsufficientTokens if amount.positive?
+
+        results
+      end
+    end
+  end
+end

--- a/lib/glueby/internal/wallet.rb
+++ b/lib/glueby/internal/wallet.rb
@@ -75,8 +75,8 @@ module Glueby
         wallet_adapter.delete_wallet(id)
       end
 
-      def sign_tx(tx)
-        wallet_adapter.sign_tx(id, tx)
+      def sign_tx(tx, prev_txs = [])
+        wallet_adapter.sign_tx(id, tx, prev_txs)
       end
 
       def receive_address

--- a/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
@@ -78,10 +78,15 @@ module Glueby
             res = client.listunspent(min_conf)
 
             res.map do |i|
+              script = Tapyrus::Script.parse_from_payload(i['scriptPubKey'].htb)
+              color_id = if script.cp2pkh? || script.cp2sh?
+                Tapyrus::Color::ColorIdentifier.parse_from_payload(script.chunks[0].pushed_data).to_hex
+              end
               {
                 txid: i['txid'],
                 vout: i['vout'],
                 script_pubkey: i['scriptPubKey'],
+                color_id: color_id,
                 amount: tpc_to_tapyrus(i['amount']),
                 finalized: i['confirmations'] != 0
               }

--- a/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
@@ -81,6 +81,7 @@ module Glueby
               {
                 txid: i['txid'],
                 vout: i['vout'],
+                script_pubkey: i['scriptPubKey'],
                 amount: tpc_to_tapyrus(i['amount']),
                 finalized: i['confirmations'] != 0
               }
@@ -88,9 +89,9 @@ module Glueby
           end
         end
 
-        def sign_tx(wallet_id, tx)
+        def sign_tx(wallet_id, tx, prevtxs = [])
           perform_as(wallet_id) do |client|
-            res = client.signrawtransactionwithwallet(tx.to_hex)
+            res = client.signrawtransactionwithwallet(tx.to_hex, prevtxs)
             if res['complete']
               Tapyrus::Tx.parse_from_payload(res['hex'].htb)
             else

--- a/lib/glueby/wallet.rb
+++ b/lib/glueby/wallet.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Glueby
+  class Wallet
+    class << self
+      def create
+        new(Glueby::Internal::Wallet.create)
+      end
+
+      def load(wallet_id)
+        new(Glueby::Internal::Wallet.load(wallet_id))
+      end
+
+      def configure(config)
+        case config[:adapter]
+        when 'core'
+          Glueby::Internal::RPC.configure(config)
+          Glueby::Internal::Wallet.wallet_adapter = Glueby::Internal::Wallet::TapyrusCoreWalletAdapter.new
+        else
+          raise 'Not implemented'
+        end
+      end
+    end
+
+    def id
+      @internal_wallet.id
+    end
+
+    # @return [HashMap] hash of balances which key is color_id or empty string, and value is amount
+    def balances
+      utxos = @internal_wallet.list_unspent
+      utxos.inject({}) do |balances, output|
+        script = Tapyrus::Script.parse_from_payload(output[:script_pubkey].htb)
+        key = if script.cp2pkh? || script.cp2sh?
+                Tapyrus::Color::ColorIdentifier.parse_from_payload(script.chunks[0].pushed_data).to_hex
+              else
+                ''
+              end
+        balances[key] ||= 0
+        balances[key] += output[:amount]
+        balances
+      end
+    end
+
+    private
+
+    def initialize(internal_wallet)
+      @internal_wallet = internal_wallet
+    end
+
+    module InternalWallet
+      refine Wallet do
+        def list_unspent
+          @internal_wallet.list_unspent
+        end
+
+        def change_address
+          @internal_wallet.change_address
+        end
+  
+        def receive_address
+          @internal_wallet.receive_address
+        end
+
+        def sign_tx(tx, prevtxs = [])
+          @internal_wallet.sign_tx(tx, prevtxs)
+        end
+      end
+    end
+  end
+end

--- a/lib/glueby/wallet.rb
+++ b/lib/glueby/wallet.rb
@@ -2,6 +2,8 @@
 
 module Glueby
   class Wallet
+    attr_reader :internal_wallet
+
     class << self
       def create
         new(Glueby::Internal::Wallet.create)

--- a/lib/glueby/wallet.rb
+++ b/lib/glueby/wallet.rb
@@ -32,12 +32,7 @@ module Glueby
     def balances
       utxos = @internal_wallet.list_unspent
       utxos.inject({}) do |balances, output|
-        script = Tapyrus::Script.parse_from_payload(output[:script_pubkey].htb)
-        key = if script.cp2pkh? || script.cp2sh?
-                Tapyrus::Color::ColorIdentifier.parse_from_payload(script.chunks[0].pushed_data).to_hex
-              else
-                ''
-              end
+        key = output[:color_id] || ''
         balances[key] ||= 0
         balances[key] += output[:amount]
         balances

--- a/lib/glueby/wallet.rb
+++ b/lib/glueby/wallet.rb
@@ -47,25 +47,5 @@ module Glueby
     def initialize(internal_wallet)
       @internal_wallet = internal_wallet
     end
-
-    module InternalWallet
-      refine Wallet do
-        def list_unspent
-          @internal_wallet.list_unspent
-        end
-
-        def change_address
-          @internal_wallet.change_address
-        end
-  
-        def receive_address
-          @internal_wallet.receive_address
-        end
-
-        def sign_tx(tx, prevtxs = [])
-          @internal_wallet.sign_tx(tx, prevtxs)
-        end
-      end
-    end
   end
 end

--- a/spec/glueby/contract/token_spec.rb
+++ b/spec/glueby/contract/token_spec.rb
@@ -1,0 +1,274 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Glueby::Contract::Token' do
+  class TestWallet
+    def list_unspent
+      []
+    end
+
+    def change_address
+      '1LUMPgobnSdbaA4iaikHKjCDLHveWYUSt5'
+    end
+
+    def receive_address
+      '1DBgMCNBdjQ1Ntz1vpwx2HMYJmc9kw88iT'
+    end
+
+    def sign_tx(tx, _prevtxs = [])
+      tx
+    end
+  end
+
+  let(:mock) { Mock.new }
+  let(:wallet) { TestWallet.new }
+  let(:unspents) do
+    [
+      {
+        txid: '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5',
+        script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+        vout: 0,
+        amount: 100_000_000,
+        finalized: false
+      }, {
+        txid: 'd49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
+        script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+        vout: 1,
+        amount: 100_000_000,
+        finalized: true
+      }, {
+        txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
+        script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+        vout: 2,
+        amount: 50_000_000,
+        finalized: true
+      }, {
+        txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
+        vout: 0,
+        script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
+        amount: 1,
+        finalized: true
+      }, {
+        txid: 'f14b29639483da7c8d17b7b7515da4ff78b91b4b89434e7988ab1bc21ab41377',
+        vout: 0,
+        script_pubkey: '21c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016bc76a914fc688c091d91789ccda7a27bd8d88be9ae4af58e88ac',
+        amount: 100_000,
+        finalized: true
+      }, {
+        txid: '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2',
+        vout: 0,
+        script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+        amount: 100_000,
+        finalized: true
+      }, {
+        txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
+        vout: 2,
+        script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+        amount: 100_000,
+        finalized: true
+      }
+    ]
+  end
+
+  let(:rpc) { double('rpc') }
+  before do
+    allow(wallet).to receive(:list_unspent).and_return(unspents)
+    allow(Glueby::Internal::RPC).to receive(:client).and_return(rpc)
+    allow(rpc).to receive(:sendrawtransaction).and_return('')
+  end
+
+  describe '.issue!' do
+    subject { Glueby::Contract::Token.issue!(issuer: issuer, token_type: token_type, amount: amount) }
+
+    let(:issuer) { wallet }
+    let(:token_type) { Tapyrus::Color::TokenTypes::REISSUABLE }
+    let(:amount) { 1_000 }
+
+    it { expect { subject }.not_to raise_error }
+    it { expect(subject.color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+
+    context 'invalid amount' do
+      let(:amount) { 0 }
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InvalidAmount }
+    end
+
+    context 'unsupported type' do
+      let(:token_type) { 0x99 }
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::UnsupportedTokenType }
+    end
+
+    context 'does not have enough tpc' do
+      let(:unspents) { [] }
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InsufficientFunds }
+    end
+  end
+
+  describe '#reissue!' do
+    subject { token.reissue!(issuer: issuer, amount: amount) }
+
+    let(:token) { Glueby::Contract::Token.issue!(issuer: issuer) }
+    let(:issuer) { wallet }
+    let(:amount) { 1_000 }
+
+    it { expect { subject }.not_to raise_error }
+
+    context 'invalid amount' do
+      let(:amount) { 0 }
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InvalidAmount }
+    end
+
+    context 'token is non reissuable' do
+      let(:token) { Glueby::Contract::Token.issue!(issuer: issuer, token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE) }
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InvalidTokenType }
+    end
+
+    context 'token is nft' do
+      let(:token) { Glueby::Contract::Token.issue!(issuer: issuer, token_type: Tapyrus::Color::TokenTypes::NFT) }
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InvalidTokenType }
+    end
+
+    context 'does not have enough tpc' do
+      let(:unspents) { [] }
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InsufficientFunds }
+    end
+  end
+
+  describe '#transfer!' do
+    subject { token.transfer!(sender: sender, receiver: receiver, amount: amount) }
+
+    let(:token) { Glueby::Contract::Token.parse_from_payload('c176a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
+    let(:sender) { wallet }
+    let(:receiver) { wallet }
+    let(:amount) { 200_000 }
+
+    it { expect { subject }.not_to raise_error }
+
+    context 'invalid amount' do
+      let(:amount) { 0 }
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InvalidAmount }
+    end
+
+    context 'does not have enough token' do
+      let(:amount) { 200_001 }
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InsufficientTokens }
+    end
+
+    context 'does not have enough tpc' do
+      let(:unspents) do
+        [{
+          txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
+          vout: 0,
+          script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
+          amount: 1,
+          finalized: true
+        }, {
+          txid: 'f14b29639483da7c8d17b7b7515da4ff78b91b4b89434e7988ab1bc21ab41377',
+          vout: 0,
+          script_pubkey: '21c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016bc76a914fc688c091d91789ccda7a27bd8d88be9ae4af58e88ac',
+          amount: 100_000,
+          finalized: true
+        }, {
+          txid: '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2',
+          vout: 0,
+          script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          amount: 100_000,
+          finalized: true
+        }, {
+          txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
+          vout: 2,
+          script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          amount: 100_000,
+          finalized: true
+        }]
+      end
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InsufficientFunds }
+    end
+  end
+
+  describe '#burn!' do
+    subject { token.burn!(sender: sender, amount: amount) }
+
+    let(:token) { Glueby::Contract::Token.parse_from_payload('c176a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
+    let(:sender) { wallet }
+    let(:amount) { 200_000 }
+
+    it { expect { subject }.not_to raise_error }
+
+    context 'invalid amount' do
+      let(:amount) { 0 }
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InvalidAmount }
+    end
+
+    context 'does not have enough token' do
+      let(:amount) { 200_001 }
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InsufficientTokens }
+    end
+
+    context 'does not have enough tpc' do
+      let(:unspents) do
+        [{
+          txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
+          vout: 0,
+          script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
+          amount: 1,
+          finalized: true
+        }, {
+          txid: 'f14b29639483da7c8d17b7b7515da4ff78b91b4b89434e7988ab1bc21ab41377',
+          vout: 0,
+          script_pubkey: '21c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016bc76a914fc688c091d91789ccda7a27bd8d88be9ae4af58e88ac',
+          amount: 100_000,
+          finalized: true
+        }, {
+          txid: '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2',
+          vout: 0,
+          script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          amount: 100_000,
+          finalized: true
+        }, {
+          txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
+          vout: 2,
+          script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          amount: 100_000,
+          finalized: true
+        }]
+      end
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InsufficientFunds }
+    end
+  end
+
+  describe '#amount' do
+    subject { token.amount(wallet: wallet) }
+
+    let(:token) { Glueby::Contract::Token.parse_from_payload('c176a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
+
+    it { is_expected.to eq 200_000 }
+  end
+
+  describe '#color_id' do
+    subject { token.color_id.to_payload.bth }
+
+    let(:token) { Glueby::Contract::Token.parse_from_payload('c176a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
+
+    it { is_expected.to eq 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3' }
+  end
+
+  describe '#to_payload' do
+    subject { token.to_payload.bth }
+
+    let(:token) { Glueby::Contract::Token.parse_from_payload('c176a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
+
+    it { is_expected.to eq 'c176a914234113b860822e68f9715d1957af28b8f5117ee288ac' }
+  end
+end

--- a/spec/glueby/contract/token_spec.rb
+++ b/spec/glueby/contract/token_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Glueby::Contract::Token' do
         amount: 100_000_000,
         finalized: false
       }, {
-        txid: 'd49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
+        txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
         script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
         vout: 1,
         amount: 100_000_000,
@@ -27,24 +27,28 @@ RSpec.describe 'Glueby::Contract::Token' do
         txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
         vout: 0,
         script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
+        color_id: 'c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893',
         amount: 1,
         finalized: true
       }, {
         txid: 'f14b29639483da7c8d17b7b7515da4ff78b91b4b89434e7988ab1bc21ab41377',
         vout: 0,
         script_pubkey: '21c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016bc76a914fc688c091d91789ccda7a27bd8d88be9ae4af58e88ac',
+        color_id: 'c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016',
         amount: 100_000,
         finalized: true
       }, {
         txid: '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2',
         vout: 0,
         script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+        color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
         amount: 100_000,
         finalized: true
       }, {
         txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
         vout: 2,
         script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+        color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
         amount: 100_000,
         finalized: true
       }
@@ -149,24 +153,28 @@ RSpec.describe 'Glueby::Contract::Token' do
           txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
           vout: 0,
           script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
+          color_id: 'c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893',
           amount: 1,
           finalized: true
         }, {
           txid: 'f14b29639483da7c8d17b7b7515da4ff78b91b4b89434e7988ab1bc21ab41377',
           vout: 0,
           script_pubkey: '21c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016bc76a914fc688c091d91789ccda7a27bd8d88be9ae4af58e88ac',
+          color_id: 'c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016',
           amount: 100_000,
           finalized: true
         }, {
           txid: '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2',
           vout: 0,
           script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
           amount: 100_000,
           finalized: true
         }, {
           txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
           vout: 2,
           script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
           amount: 100_000,
           finalized: true
         }]
@@ -203,24 +211,28 @@ RSpec.describe 'Glueby::Contract::Token' do
           txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
           vout: 0,
           script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
+          color_id: 'c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893',
           amount: 1,
           finalized: true
         }, {
           txid: 'f14b29639483da7c8d17b7b7515da4ff78b91b4b89434e7988ab1bc21ab41377',
           vout: 0,
           script_pubkey: '21c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016bc76a914fc688c091d91789ccda7a27bd8d88be9ae4af58e88ac',
+          color_id: 'c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016',
           amount: 100_000,
           finalized: true
         }, {
           txid: '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2',
           vout: 0,
           script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
           amount: 100_000,
           finalized: true
         }, {
           txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
           vout: 2,
           script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
           amount: 100_000,
           finalized: true
         }]

--- a/spec/glueby/contract/token_spec.rb
+++ b/spec/glueby/contract/token_spec.rb
@@ -2,9 +2,7 @@
 
 RSpec.describe 'Glueby::Contract::Token' do
   class TestWallet
-    def internal_wallet
-      @internal_wallet
-    end
+    attr_reader :internal_wallet
 
     def initialize(internal_wallet)
       @internal_wallet = internal_wallet

--- a/spec/glueby/contract/token_spec.rb
+++ b/spec/glueby/contract/token_spec.rb
@@ -1,33 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Glueby::Contract::Token' do
-  class TestWallet
-    attr_reader :internal_wallet
-
-    def initialize(internal_wallet)
-      @internal_wallet = internal_wallet
-    end
-  end
-
-  class TestInternalWallet
-    def receive_address
-      '1DBgMCNBdjQ1Ntz1vpwx2HMYJmc9kw88iT'
-    end
-
-    def list_unspent
-      []
-    end
-
-    def change_address
-      '1LUMPgobnSdbaA4iaikHKjCDLHveWYUSt5'
-    end
-  
-    def sign_tx(tx, _prevtxs = [])
-      tx
-    end
-  end
-
-  let(:mock) { Mock.new }
   let(:wallet) { TestWallet.new(internal_wallet) }
   let(:internal_wallet) { TestInternalWallet.new }
   let(:unspents) do

--- a/spec/glueby/contract/token_spec.rb
+++ b/spec/glueby/contract/token_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe 'Glueby::Contract::Token' do
   describe '#transfer!' do
     subject { token.transfer!(sender: sender, receiver: receiver, amount: amount) }
 
-    let(:token) { Glueby::Contract::Token.parse_from_payload('c176a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
+    let(:token) { Glueby::Contract::Token.parse_from_payload('c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb376a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
     let(:sender) { wallet }
     let(:receiver) { wallet }
     let(:amount) { 200_000 }
@@ -187,7 +187,7 @@ RSpec.describe 'Glueby::Contract::Token' do
   describe '#burn!' do
     subject { token.burn!(sender: sender, amount: amount) }
 
-    let(:token) { Glueby::Contract::Token.parse_from_payload('c176a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
+    let(:token) { Glueby::Contract::Token.parse_from_payload('c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb376a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
     let(:sender) { wallet }
     let(:amount) { 200_000 }
 
@@ -245,7 +245,7 @@ RSpec.describe 'Glueby::Contract::Token' do
   describe '#amount' do
     subject { token.amount(wallet: wallet) }
 
-    let(:token) { Glueby::Contract::Token.parse_from_payload('c176a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
+    let(:token) { Glueby::Contract::Token.parse_from_payload('c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb376a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
 
     it { is_expected.to eq 200_000 }
   end
@@ -253,16 +253,28 @@ RSpec.describe 'Glueby::Contract::Token' do
   describe '#color_id' do
     subject { token.color_id.to_payload.bth }
 
-    let(:token) { Glueby::Contract::Token.parse_from_payload('c176a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
+    let(:token) { Glueby::Contract::Token.parse_from_payload('c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb376a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
 
     it { is_expected.to eq 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3' }
+
+    context 'with no script pubkey' do
+      let(:token) { Glueby::Contract::Token.parse_from_payload('c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3'.htb) }
+
+      it { is_expected.to eq 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3' }
+    end
   end
 
   describe '#to_payload' do
     subject { token.to_payload.bth }
 
-    let(:token) { Glueby::Contract::Token.parse_from_payload('c176a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
+    let(:token) { Glueby::Contract::Token.parse_from_payload('c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb376a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
 
-    it { is_expected.to eq 'c176a914234113b860822e68f9715d1957af28b8f5117ee288ac' }
+    it { is_expected.to eq 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb376a914234113b860822e68f9715d1957af28b8f5117ee288ac' }
+
+    context 'with no script pubkey' do
+      let(:token) { Glueby::Contract::Token.parse_from_payload('c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3'.htb) }
+
+      it { is_expected.to eq 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3' }
+    end
   end
 end

--- a/spec/glueby/contract/token_spec.rb
+++ b/spec/glueby/contract/token_spec.rb
@@ -2,6 +2,20 @@
 
 RSpec.describe 'Glueby::Contract::Token' do
   class TestWallet
+    def internal_wallet
+      @internal_wallet
+    end
+
+    def initialize(internal_wallet)
+      @internal_wallet = internal_wallet
+    end
+  end
+
+  class TestInternalWallet
+    def receive_address
+      '1DBgMCNBdjQ1Ntz1vpwx2HMYJmc9kw88iT'
+    end
+
     def list_unspent
       []
     end
@@ -9,18 +23,15 @@ RSpec.describe 'Glueby::Contract::Token' do
     def change_address
       '1LUMPgobnSdbaA4iaikHKjCDLHveWYUSt5'
     end
-
-    def receive_address
-      '1DBgMCNBdjQ1Ntz1vpwx2HMYJmc9kw88iT'
-    end
-
+  
     def sign_tx(tx, _prevtxs = [])
       tx
     end
   end
 
   let(:mock) { Mock.new }
-  let(:wallet) { TestWallet.new }
+  let(:wallet) { TestWallet.new(internal_wallet) }
+  let(:internal_wallet) { TestInternalWallet.new }
   let(:unspents) do
     [
       {
@@ -71,7 +82,7 @@ RSpec.describe 'Glueby::Contract::Token' do
 
   let(:rpc) { double('rpc') }
   before do
-    allow(wallet).to receive(:list_unspent).and_return(unspents)
+    allow(internal_wallet).to receive(:list_unspent).and_return(unspents)
     allow(Glueby::Internal::RPC).to receive(:client).and_return(rpc)
     allow(rpc).to receive(:sendrawtransaction).and_return('')
   end

--- a/spec/glueby/contract/token_tx_builder_spec.rb
+++ b/spec/glueby/contract/token_tx_builder_spec.rb
@@ -5,32 +5,6 @@ RSpec.describe 'Glueby::Contract::TokenTxBuilder' do
     include Glueby::Contract::TokenTxBuilder
   end
 
-  class TestWallet
-    attr_reader :internal_wallet
-
-    def initialize(internal_wallet)
-      @internal_wallet = internal_wallet
-    end
-  end
-
-  class TestInternalWallet
-    def list_unspent
-      []
-    end
-
-    def receive_address
-      '1DBgMCNBdjQ1Ntz1vpwx2HMYJmc9kw88iT'
-    end
-
-    def change_address
-      '1LUMPgobnSdbaA4iaikHKjCDLHveWYUSt5'
-    end
-  
-    def sign_tx(tx, _prevtxs = [])
-      tx
-    end
-  end
-
   let(:mock) { TokenTxBuilderMock.new }
   let(:wallet) { TestWallet.new(internal_wallet) }
   let(:internal_wallet) { TestInternalWallet.new }

--- a/spec/glueby/contract/token_tx_builder_spec.rb
+++ b/spec/glueby/contract/token_tx_builder_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe 'Glueby::Contract::TokenTxBuilder' do
   end
 
   class TestWallet
-    def internal_wallet
-      @internal_wallet
-    end
+    attr_reader :internal_wallet
 
     def initialize(internal_wallet)
       @internal_wallet = internal_wallet

--- a/spec/glueby/contract/token_tx_builder_spec.rb
+++ b/spec/glueby/contract/token_tx_builder_spec.rb
@@ -1,0 +1,317 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Glueby::Contract::TokenTxBuilder' do
+  class TokenTxBuilderMock
+    include Glueby::Contract::TokenTxBuilder
+  end
+
+  class TestWallet
+    def list_unspent
+      []
+    end
+
+    def change_address
+      '1LUMPgobnSdbaA4iaikHKjCDLHveWYUSt5'
+    end
+
+    def receive_address
+      '1DBgMCNBdjQ1Ntz1vpwx2HMYJmc9kw88iT'
+    end
+
+    def sign_tx(tx, _prevtxs = [])
+      tx
+    end
+  end
+
+  let(:mock) { TokenTxBuilderMock.new }
+  let(:wallet) { TestWallet.new }
+  let(:unspents) do
+    [
+      {
+        txid: '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5',
+        script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+        vout: 0,
+        amount: 100_000_000,
+        finalized: false
+      }, {
+        txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
+        script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+        vout: 1,
+        amount: 100_000_000,
+        finalized: true
+      }, {
+        txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
+        script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+        vout: 2,
+        amount: 50_000_000,
+        finalized: true
+      }, {
+        txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
+        vout: 0,
+        script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
+        amount: 1,
+        finalized: true
+      }, {
+        txid: 'f14b29639483da7c8d17b7b7515da4ff78b91b4b89434e7988ab1bc21ab41377',
+        vout: 0,
+        script_pubkey: '21c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016bc76a914fc688c091d91789ccda7a27bd8d88be9ae4af58e88ac',
+        amount: 100_000,
+        finalized: true
+      }, {
+        txid: '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2',
+        vout: 0,
+        script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+        amount: 100_000,
+        finalized: true
+      }, {
+        txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
+        vout: 2,
+        script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+        amount: 100_000,
+        finalized: true
+      }
+    ]
+  end
+
+  before { allow(wallet).to receive(:list_unspent).and_return(unspents) }
+
+  describe '#create_funding_tx' do
+    subject { mock.create_funding_tx(wallet: wallet, amount: amount) }
+
+    let(:amount) { 100_000_000 }
+
+    it { expect(subject.inputs.size).to eq 2 }
+    it { expect(subject.inputs[0].out_point.txid).to eq '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5' }
+    it { expect(subject.inputs[0].out_point.index).to eq 0 }
+    it { expect(subject.inputs[1].out_point.txid).to eq '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db' }
+    it { expect(subject.inputs[1].out_point.index).to eq 1 }
+    it { expect(subject.outputs.size).to eq 2 }
+    it { expect(subject.outputs[0].value).to eq 100_000_000 }
+    it { expect(subject.outputs[1].value).to eq 99_990_000 }
+  end
+
+  describe '#create_issue_tx_for_reissuable_token' do
+    subject { mock.create_issue_tx_for_reissuable_token(funding_tx: funding_tx, issuer: issuer, amount: amount) }
+
+    let(:funding_tx) do
+      tx = Tapyrus::Tx.new
+      tx.inputs << Tapyrus::TxIn.new(out_point: Tapyrus::OutPoint.from_txid('5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5', 0))
+      tx.outputs << Tapyrus::TxOut.new(value: 100_000_000, script_pubkey: script_pubkey)
+      tx
+    end
+    let(:script_pubkey) { Tapyrus::Script.parse_from_payload('76a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
+    let(:issuer) { wallet }
+    let(:amount) { 1_000 }
+
+    it { expect(subject.inputs.size).to eq 1 }
+    it { expect(subject.inputs[0].out_point.txid).to eq funding_tx.txid }
+    it { expect(subject.inputs[0].out_point.index).to eq 0 }
+    it { expect(subject.outputs.size).to eq 2 }
+    it { expect(subject.outputs[0].value).to eq 1_000 }
+    it { expect(subject.outputs[0].colored?).to be_truthy }
+    it { expect(subject.outputs[0].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+    it { expect(subject.outputs[1].value).to eq 99_990_000 }
+  end
+
+  describe '#create_issue_tx_for_non_reissuable_token' do
+    subject { mock.create_issue_tx_for_non_reissuable_token(issuer: issuer, amount: amount) }
+
+    let(:issuer) { wallet }
+    let(:amount) { 1_000 }
+
+    it { expect(subject.inputs.size).to eq 1 }
+    it { expect(subject.inputs[0].out_point.txid).to eq '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5' }
+    it { expect(subject.inputs[0].out_point.index).to eq 0 }
+    it { expect(subject.outputs.size).to eq 2 }
+    it { expect(subject.outputs[0].value).to eq 1_000 }
+    it { expect(subject.outputs[0].colored?).to be_truthy }
+    it { expect(subject.outputs[0].color_id.type).to eq Tapyrus::Color::TokenTypes::NON_REISSUABLE }
+    it { expect(subject.outputs[1].value).to eq 99_990_000 }
+  end
+
+  describe '#create_issue_tx_for_nft_token' do
+    subject { mock.create_issue_tx_for_nft_token(issuer: issuer) }
+
+    let(:issuer) { wallet }
+
+    it { expect(subject.inputs.size).to eq 1 }
+    it { expect(subject.inputs[0].out_point.txid).to eq '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5' }
+    it { expect(subject.inputs[0].out_point.index).to eq 0 }
+    it { expect(subject.outputs.size).to eq 2 }
+    it { expect(subject.outputs[0].value).to eq 1 }
+    it { expect(subject.outputs[0].colored?).to be_truthy }
+    it { expect(subject.outputs[0].color_id.type).to eq Tapyrus::Color::TokenTypes::NFT }
+    it { expect(subject.outputs[1].value).to eq 99_990_000 }
+  end
+
+  describe '#create_reissue_tx' do
+    subject { mock.create_reissue_tx(issuer: issuer, amount: amount, funding_script: funding_script, color_id: color_id) }
+
+    let(:issuer) { wallet }
+    let(:amount) { 1_000 }
+    let(:funding_script) { Tapyrus::Script.parse_from_payload('76a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
+    let(:color_id) { Tapyrus::Color::ColorIdentifier.parse_from_payload('c185856a84c483fb108b1cdf79ff53aa7d54d1a137a5178684bd89ca31f906b2bd'.htb) }
+
+    it { expect(subject.size).to eq 2 }
+    it { expect(subject[1].inputs.size).to eq 1 }
+    it { expect(subject[1].outputs.size).to eq 1 }
+    it { expect(subject[1].outputs[0].value).to eq 1_000 }
+    it { expect(subject[1].outputs[0].colored?).to be_truthy }
+    it { expect(subject[1].outputs[0].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+  end
+  
+  describe '#create_transfer_tx' do
+    subject { mock.create_transfer_tx(color_id: color_id, sender: sender, receiver: receiver, amount: amount) }
+
+    let(:color_id) { Tapyrus::Color::ColorIdentifier.parse_from_payload('c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3'.htb) }
+    let(:sender) { wallet }
+    let(:receiver) { wallet }
+    let(:amount) { 100_001 }
+
+    it { expect(subject.inputs.size).to eq 3 }
+    it { expect(subject.inputs[0].out_point.txid).to eq '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5' }
+    it { expect(subject.inputs[0].out_point.index).to eq 0 }
+    it { expect(subject.inputs[1].out_point.txid).to eq '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2' }
+    it { expect(subject.inputs[1].out_point.index).to eq 0 }
+    it { expect(subject.inputs[2].out_point.txid).to eq 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9' }
+    it { expect(subject.inputs[2].out_point.index).to eq 2 }
+    it { expect(subject.outputs.size).to eq 3 }
+    it { expect(subject.outputs[0].value).to eq 100_001 }
+    it { expect(subject.outputs[0].colored?).to be_truthy }
+    it { expect(subject.outputs[0].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+    it { expect(subject.outputs[1].value).to eq 99_999 }
+    it { expect(subject.outputs[1].colored?).to be_truthy }
+    it { expect(subject.outputs[1].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+    it { expect(subject.outputs[2].value).to eq 99_990_000 }
+  end
+
+  describe '#create_burn_tx' do
+    subject { mock.create_burn_tx(color_id: color_id, sender: sender, amount: amount, fee_provider: fee_provider) }
+
+    let(:color_id) { Tapyrus::Color::ColorIdentifier.parse_from_payload('c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3'.htb) }
+    let(:sender) { wallet }
+    let(:amount) { 50_000 }
+    let(:fee_provider) { Glueby::Contract::FixedFeeProvider.new }
+
+    it { expect(subject.inputs.size).to eq 2 }
+    it { expect(subject.inputs[0].out_point.txid).to eq '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5' }
+    it { expect(subject.inputs[0].out_point.index).to eq 0 }
+    it { expect(subject.inputs[1].out_point.txid).to eq '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2' }
+    it { expect(subject.inputs[1].out_point.index).to eq 0 }
+    it { expect(subject.outputs.size).to eq 2 }
+    it { expect(subject.outputs[0].value).to eq 50_000 }
+    it { expect(subject.outputs[0].colored?).to be_truthy }
+    it { expect(subject.outputs[1].value).to eq 99_990_000 }
+    it { expect(subject.outputs[1].colored?).to be_falsy }
+
+    context 'if specified amount is 0' do
+      let(:amount) { 0 }
+
+      it { expect(subject.outputs.size).to eq 1 }
+      it { expect(subject.outputs[0].value).to eq 99_990_000 }
+      it { expect(subject.outputs[0].colored?).to be_falsy }
+    end
+
+    context 'tx fee is same as value of the first utxo' do
+      let(:fee_provider) { Glueby::Contract::FixedFeeProvider.new(fixed_fee: 100_000_000) }
+      let(:amount) { 0 }
+
+      it 'should have at least one output' do
+        expect(subject.inputs.size).to eq 4
+        expect(subject.inputs[0].out_point.txid).to eq '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5'
+        expect(subject.inputs[0].out_point.index).to eq 0
+        expect(subject.inputs[1].out_point.txid).to eq '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db'
+        expect(subject.inputs[1].out_point.index).to eq 1
+        expect(subject.inputs[2].out_point.txid).to eq '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2'
+        expect(subject.inputs[2].out_point.index).to eq 0
+        expect(subject.inputs[3].out_point.txid).to eq 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9'
+        expect(subject.inputs[3].out_point.index).to eq 2
+        expect(subject.outputs.size).to eq 1
+        expect(subject.outputs[0].value).to eq 100_000_000
+        expect(subject.outputs[0].colored?).to be_falsy
+      end
+    end
+  end
+
+  describe '#fill_input' do
+    subject { mock.fill_input(tx, outputs) }
+
+    let(:tx) { Tapyrus::Tx.new }
+    let(:outputs) { unspents }
+
+    it { expect { subject }.to change { tx.inputs.size }.from(0).to(7) }
+  end
+
+  describe '#fill_change_tpc' do
+    subject { mock.fill_change_tpc(tx, wallet, amount) }
+    let(:tx) { Tapyrus::Tx.new }
+    let(:wallet) { TestWallet.new }
+    let(:amount) { 1 }
+
+    it { expect { subject }.to change { tx.outputs.size }.from(0).to(1) }
+
+    context 'if change is 0' do
+      let(:amount) { 0 }
+
+      it { expect { subject }.not_to change { tx.outputs.size } }
+    end
+  end
+
+  describe '#fill_change_token' do
+    subject { mock.fill_change_token(tx, wallet, amount, color_id) }
+
+    let(:tx) { Tapyrus::Tx.new }
+    let(:amount) { 1 }
+    let(:color_id) { Tapyrus::Color::ColorIdentifier.parse_from_payload('c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893'.htb) }
+
+    it { expect { subject }.to change { tx.outputs.size }.from(0).to(1) }
+
+    context 'if change is 0' do
+      let(:amount) { 0 }
+
+      it { expect { subject }.not_to change { tx.outputs.size } }
+    end
+  end
+
+  describe '#collect_uncolored_outputs' do
+    subject { mock.collect_uncolored_outputs(results, amount) }
+
+    let(:results) { unspents }
+    let(:amount) { 150_000_000 }
+
+    it { expect(subject[0]).to eq 200_000_000 }
+    it { expect(subject[1].size).to eq 2 }
+
+    context 'does not have enough tpc' do
+      let(:amount) { 250_000_001 }
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InsufficientFunds }
+    end
+  end
+
+  describe '#collect_colored_outputs' do
+    subject { mock.collect_colored_outputs(results, color_id, amount) }
+
+    let(:results) { unspents }
+    let(:amount) { 50_000 }
+    let(:color_id) { Tapyrus::Color::ColorIdentifier.parse_from_payload('c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3'.htb) }
+
+    it { expect(subject[0]).to eq 100_000 }
+    it { expect(subject[1].size).to eq 1 }
+
+    context 'does not have enough token' do
+      let(:amount) { 200_001 }
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InsufficientTokens }
+    end
+
+    context 'if specified amount is 0' do
+      let(:amount) { 0 }
+
+      it 'should return all outputs which has the color_id' do
+        expect(subject[0]).to eq 200_000
+        expect(subject[1].size).to eq 2
+      end
+    end
+  end
+end

--- a/spec/glueby/contract/token_tx_builder_spec.rb
+++ b/spec/glueby/contract/token_tx_builder_spec.rb
@@ -32,24 +32,28 @@ RSpec.describe 'Glueby::Contract::TokenTxBuilder' do
         txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
         vout: 0,
         script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
+        color_id: 'c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893',
         amount: 1,
         finalized: true
       }, {
         txid: 'f14b29639483da7c8d17b7b7515da4ff78b91b4b89434e7988ab1bc21ab41377',
         vout: 0,
         script_pubkey: '21c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016bc76a914fc688c091d91789ccda7a27bd8d88be9ae4af58e88ac',
+        color_id: 'c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016',
         amount: 100_000,
         finalized: true
       }, {
         txid: '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2',
         vout: 0,
         script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+        color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
         amount: 100_000,
         finalized: true
       }, {
         txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
         vout: 2,
         script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+        color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
         amount: 100_000,
         finalized: true
       }

--- a/spec/glueby/contract/token_tx_builder_spec.rb
+++ b/spec/glueby/contract/token_tx_builder_spec.rb
@@ -163,12 +163,12 @@ RSpec.describe 'Glueby::Contract::TokenTxBuilder' do
     let(:amount) { 100_001 }
 
     it { expect(subject.inputs.size).to eq 3 }
-    it { expect(subject.inputs[0].out_point.txid).to eq '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5' }
+    it { expect(subject.inputs[0].out_point.txid).to eq '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2' }
     it { expect(subject.inputs[0].out_point.index).to eq 0 }
-    it { expect(subject.inputs[1].out_point.txid).to eq '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2' }
-    it { expect(subject.inputs[1].out_point.index).to eq 0 }
-    it { expect(subject.inputs[2].out_point.txid).to eq 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9' }
-    it { expect(subject.inputs[2].out_point.index).to eq 2 }
+    it { expect(subject.inputs[1].out_point.txid).to eq 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9' }
+    it { expect(subject.inputs[1].out_point.index).to eq 2 }
+    it { expect(subject.inputs[2].out_point.txid).to eq '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5' }
+    it { expect(subject.inputs[2].out_point.index).to eq 0 }
     it { expect(subject.outputs.size).to eq 3 }
     it { expect(subject.outputs[0].value).to eq 100_001 }
     it { expect(subject.outputs[0].colored?).to be_truthy }
@@ -188,9 +188,9 @@ RSpec.describe 'Glueby::Contract::TokenTxBuilder' do
     let(:fee_provider) { Glueby::Contract::FixedFeeProvider.new }
 
     it { expect(subject.inputs.size).to eq 2 }
-    it { expect(subject.inputs[0].out_point.txid).to eq '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5' }
+    it { expect(subject.inputs[0].out_point.txid).to eq '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2' }
     it { expect(subject.inputs[0].out_point.index).to eq 0 }
-    it { expect(subject.inputs[1].out_point.txid).to eq '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2' }
+    it { expect(subject.inputs[1].out_point.txid).to eq '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5' }
     it { expect(subject.inputs[1].out_point.index).to eq 0 }
     it { expect(subject.outputs.size).to eq 2 }
     it { expect(subject.outputs[0].value).to eq 50_000 }
@@ -212,14 +212,14 @@ RSpec.describe 'Glueby::Contract::TokenTxBuilder' do
 
       it 'should have at least one output' do
         expect(subject.inputs.size).to eq 4
-        expect(subject.inputs[0].out_point.txid).to eq '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5'
+        expect(subject.inputs[0].out_point.txid).to eq '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2'
         expect(subject.inputs[0].out_point.index).to eq 0
-        expect(subject.inputs[1].out_point.txid).to eq '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db'
-        expect(subject.inputs[1].out_point.index).to eq 1
-        expect(subject.inputs[2].out_point.txid).to eq '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2'
+        expect(subject.inputs[1].out_point.txid).to eq 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9'
+        expect(subject.inputs[1].out_point.index).to eq 2
+        expect(subject.inputs[2].out_point.txid).to eq '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5'
         expect(subject.inputs[2].out_point.index).to eq 0
-        expect(subject.inputs[3].out_point.txid).to eq 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9'
-        expect(subject.inputs[3].out_point.index).to eq 2
+        expect(subject.inputs[3].out_point.txid).to eq '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db'
+        expect(subject.inputs[3].out_point.index).to eq 1
         expect(subject.outputs.size).to eq 1
         expect(subject.outputs[0].value).to eq 100_000_000
         expect(subject.outputs[0].colored?).to be_falsy
@@ -306,5 +306,21 @@ RSpec.describe 'Glueby::Contract::TokenTxBuilder' do
         expect(subject[1].size).to eq 2
       end
     end
+  end
+
+  describe '#dummy_tx' do
+    subject { mock.dummy_tx(Tapyrus::Tx.new) }
+
+    it { expect(subject.inputs.size).to eq 1 }
+    it { expect(subject.outputs.size).to eq 1 }
+  end
+
+  describe '#dummy_issue_tx_from_out_point' do
+    subject { mock.dummy_issue_tx_from_out_point }
+
+    it { expect(subject.inputs.size).to eq 1 }
+    it { expect(subject.outputs.size).to eq 2 }
+    it { expect(subject.outputs[0].colored?).to be_truthy }
+    it { expect(subject.outputs[1].colored?).to be_falsy }
   end
 end

--- a/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
+++ b/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
@@ -151,12 +151,14 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
       expect(subject).to eq([
                               {
                                 txid: "5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5",
+                                script_pubkey: "76a914234113b860822e68f9715d1957af28b8f5117ee288ac",
                                 vout: 0,
                                 amount: 100000000,
                                 finalized: false
                               },
                               {
                                 txid: "1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db",
+                                script_pubkey: "76a914234113b860822e68f9715d1957af28b8f5117ee288ac",
                                 vout: 1,
                                 amount: 100000000,
                                 finalized: true

--- a/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
+++ b/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
@@ -141,6 +141,18 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
             "spendable": true,
             "solvable": true,
             "safe": false
+          },
+          {
+            "txid": "864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5",
+            "vout": 0,
+            "address": "w25MP2mrNU4oFqouSdwmSJHd8YntErqMwYk3vHr6RRjwZYWV6NfNZhgMfVWABRadn3RutmxAogoQCG",
+            "label": "",
+            "scriptPubKey": "21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac",
+            "amount": "0.00000001",
+            "confirmations": 1,
+            "spendable": true,
+            "solvable": true,
+            "safe": false
           }
         ]
       JSON
@@ -154,6 +166,7 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
                                 script_pubkey: "76a914234113b860822e68f9715d1957af28b8f5117ee288ac",
                                 vout: 0,
                                 amount: 100000000,
+                                color_id: nil,
                                 finalized: false
                               },
                               {
@@ -161,6 +174,15 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
                                 script_pubkey: "76a914234113b860822e68f9715d1957af28b8f5117ee288ac",
                                 vout: 1,
                                 amount: 100000000,
+                                color_id: nil,
+                                finalized: true
+                              },
+                              {
+                                txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
+                                vout: 0,
+                                script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
+                                color_id: 'c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893',
+                                amount: 1,
                                 finalized: true
                               }
                             ])

--- a/spec/glueby/wallet_spec.rb
+++ b/spec/glueby/wallet_spec.rb
@@ -21,24 +21,28 @@ RSpec.describe 'Glueby::Wallet' do
           txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
           vout: 0,
           script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
+          color_id: 'c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893',
           amount: 1,
           finalized: true
         }, {
           txid: 'f14b29639483da7c8d17b7b7515da4ff78b91b4b89434e7988ab1bc21ab41377',
           vout: 0,
           script_pubkey: '21c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016bc76a914fc688c091d91789ccda7a27bd8d88be9ae4af58e88ac',
+          color_id: 'c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016',
           amount: 100_000,
           finalized: true
         }, {
           txid: '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2',
           vout: 0,
           script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
           amount: 100_000,
           finalized: true
         }, {
           txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
           vout: 2,
           script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
           amount: 100_000,
           finalized: true
         }

--- a/spec/glueby/wallet_spec.rb
+++ b/spec/glueby/wallet_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Glueby::Wallet' do
+  class TestWalletAdapter < Glueby::Internal::Wallet::AbstractWalletAdapter
+    def create_wallet; end
+    def list_unspent(wallet_id, only_finalized = true)
+      [
+        {
+          txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
+          script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+          vout: 1,
+          amount: 100_000_000,
+          finalized: true
+        }, {
+          txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
+          script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+          vout: 2,
+          amount: 50_000_000,
+          finalized: true
+        }, {
+          txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
+          vout: 0,
+          script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
+          amount: 1,
+          finalized: true
+        }, {
+          txid: 'f14b29639483da7c8d17b7b7515da4ff78b91b4b89434e7988ab1bc21ab41377',
+          vout: 0,
+          script_pubkey: '21c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016bc76a914fc688c091d91789ccda7a27bd8d88be9ae4af58e88ac',
+          amount: 100_000,
+          finalized: true
+        }, {
+          txid: '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2',
+          vout: 0,
+          script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          amount: 100_000,
+          finalized: true
+        }, {
+          txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
+          vout: 2,
+          script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          amount: 100_000,
+          finalized: true
+        }
+      ]
+    end
+  end
+
+  before { Glueby::Internal::Wallet.wallet_adapter = TestWalletAdapter.new }
+  after { Glueby::Internal::Wallet.wallet_adapter = nil }
+
+  describe '#balances' do
+    subject { wallet.balances }
+
+    let(:wallet) { Glueby::Wallet.create }
+    let(:expected) do
+      {
+        '' => 150_000_000, 
+        'c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893' => 1,
+        'c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016' => 100_000,
+        'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3' => 200_000
+      }
+    end
+    it { is_expected.to eq expected }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,3 +13,29 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 end
+
+class TestWallet
+  attr_reader :internal_wallet
+
+  def initialize(internal_wallet)
+    @internal_wallet = internal_wallet
+  end
+end
+
+class TestInternalWallet
+  def receive_address
+    '1DBgMCNBdjQ1Ntz1vpwx2HMYJmc9kw88iT'
+  end
+
+  def list_unspent
+    []
+  end
+
+  def change_address
+    '1LUMPgobnSdbaA4iaikHKjCDLHveWYUSt5'
+  end
+
+  def sign_tx(tx, _prevtxs = [])
+    tx
+  end
+end


### PR DESCRIPTION
This PR implements Token issurance, transfering, and burn for next Tapyrus version 0.5.0