### PR TITLE
TapyrusCoreClient should be initialized just before RPC call

### DIFF
--- a/lib/glueby/internal/rpc.rb
+++ b/lib/glueby/internal/rpc.rb
@@ -4,11 +4,11 @@ module Glueby
       module_function
 
       def client
-        @rpc
+        @rpc ||= Tapyrus::RPC::TapyrusCoreClient.new(@config)
       end
 
       def configure(config)
-        @rpc = Tapyrus::RPC::TapyrusCoreClient.new(config)
+        @config = config
       end
 
       # Perform RPC call on the specific wallet.


### PR DESCRIPTION
When i use glueby gem in my rails apps, i will write initialization in config/initializers/glueby.rb like this:

```
config = YAML.load("config/tapyrus.yml")
Glueby::Internal::RPC.configure(config)
```

This code works as long as TapyrusCore is running.
But I think we don't need to run TapyrusCore for every `bundle exec` including migration or rspec test.

This PR will make initialization of Tapyrus::RPC::TapyrusCoreClient instance lazy and will allow us to drive development without running TapyrusCore.
