### PR TITLE
Fix signature error when using ActiveRecordWalletAdapter

### DIFF
--- a/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
@@ -82,9 +82,11 @@ module Glueby
         # Sign to the transaction with a key in the wallet.
         #
         # @param [String] wallet_id - The wallet id that is offered by `create_wallet()` method.
-        # @param [Tapyrus::Tx] tx - The Transaction will be signed.
+        # @param [Tapyrus::Tx] tx - The transaction will be signed.
+        # @param [Array] prevtxs array of hash that represents unbroadcasted transaction outputs used by signing tx. 
+        #                Each hash has `txid`, `vout`, `scriptPubKey`, `amount` fields.
         # @return [Tapyrus::Tx]
-        def sign_tx(wallet_id, tx)
+        def sign_tx(wallet_id, tx, prevtxs = [])
           raise NotImplementedError, "You must implement #{self.class}##{__method__}"
         end
 

--- a/lib/glueby/internal/wallet/active_record/key.rb
+++ b/lib/glueby/internal/wallet/active_record/key.rb
@@ -27,19 +27,6 @@ module Glueby
             to_p2pkh.addresses.first
           end
 
-          # Return Glueby::Internal::Wallet::AR::Key object for input.
-          # If utxo spent by the specified input is colored output, key is found by corresponding `uncolored` script.
-          #
-          # @param [Tapyrus::TxIn] input
-          # @return [Glueby::Internal::Wallet::AR::Key] key for input
-          def self.key_for_input(input)
-            out_point = input.out_point
-            utxo = Utxo.find_by(txid: out_point.txid, index: out_point.index)
-            return unless utxo
-            script_pubkey = Tapyrus::Script.parse_from_payload(utxo.script_pubkey.htb)
-            key_for_script(script_pubkey)
-          end
-
           # Return Glueby::Internal::Wallet::AR::Key object for output.
           # If output is colored output, key is found by corresponding `uncolored` script.
           #

--- a/lib/glueby/internal/wallet/active_record/key.rb
+++ b/lib/glueby/internal/wallet/active_record/key.rb
@@ -36,8 +36,6 @@ module Glueby
             key_for_script(output.script_pubkey)
           end
 
-          private
-
           # Return Glueby::Internal::Wallet::AR::Key object for script.
           # If script is colored, key is found by corresponding `uncolored` script.
           #
@@ -51,6 +49,8 @@ module Glueby
             end
             find_by(script_pubkey: script_pubkey)
           end
+
+          private
 
           def generate_key
             key = if private_key

--- a/lib/glueby/internal/wallet/active_record/wallet.rb
+++ b/lib/glueby/internal/wallet/active_record/wallet.rb
@@ -12,11 +12,14 @@ module Glueby
           validates :wallet_id, uniqueness: { case_sensitive: false }
 
           # @param [Tapyrus::Tx] tx
-          def sign(tx)
+          # @param [Array] prevtxs array of outputs
+          def sign(tx, prevtxs = [])
             tx.inputs.each.with_index do |input, index|
-              key = Key.key_for_input(input)
+              script_pubkey = script_for_input(input, prevtxs)
+              next unless script_pubkey
+              key = Key.key_for_script(script_pubkey)
               next unless key
-              sign_tx_for_p2pkh(tx, index, key)
+              sign_tx_for_p2pkh(tx, index, key, script_pubkey)
             end
             tx
           end
@@ -27,11 +30,22 @@ module Glueby
 
           private
 
-          def sign_tx_for_p2pkh(tx, index, key)
-            sighash = tx.sighash_for_input(index, key.to_p2pkh)
+          def sign_tx_for_p2pkh(tx, index, key, script_pubkey)
+            sighash = tx.sighash_for_input(index, script_pubkey)
             sig = key.sign(sighash) + [Tapyrus::SIGHASH_TYPE[:all]].pack('C')
             script_sig = Tapyrus::Script.parse_from_payload(Tapyrus::Script.pack_pushdata(sig) + Tapyrus::Script.pack_pushdata(key.public_key.htb))
             tx.inputs[index].script_sig = script_sig
+          end
+
+          def script_for_input(input, prevtxs = [])
+            out_point = input.out_point
+            utxo = Utxo.find_by(txid: out_point.txid, index: out_point.index)
+            if utxo
+              Tapyrus::Script.parse_from_payload(utxo.script_pubkey.htb)
+            else
+              output = prevtxs.select { |output| output[:txid] == out_point.txid && output[:vout] == out_point.index }.first
+              Tapyrus::Script.parse_from_payload(output[:scriptPubKey].htb) if output
+            end
           end
         end
       end

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -51,7 +51,7 @@ module Glueby
 
         def sign_tx(wallet_id, tx, prevtxs = [])
           wallet = AR::Wallet.find_by(wallet_id: wallet_id)
-          wallet.sign(tx)
+          wallet.sign(tx, prevtxs)
         end
 
         def receive_address(wallet_id)

--- a/spec/glueby/internal/wallet/active_record/key_spec.rb
+++ b/spec/glueby/internal/wallet/active_record/key_spec.rb
@@ -104,49 +104,6 @@ RSpec.describe 'Glueby::Internal::Wallet::AR::Key' do
     it { expect(Tapyrus::Key.new(priv_key: private_key).verify(subject.htb, data, algo: :schnorr)).to be_truthy }
   end
 
-  describe '.key_for_input' do
-    subject { Glueby::Internal::Wallet::AR::Key.key_for_input(input) }
-
-    let(:input) { Tapyrus::TxIn.new(out_point: Tapyrus::OutPoint.from_txid('0000000000000000000000000000000000000000000000000000000000000000', 0)) }
-
-    context 'utxo exists' do
-      before do
-        Glueby::Internal::Wallet::AR::Utxo.create(
-          txid: '0000000000000000000000000000000000000000000000000000000000000000',
-          index: 0,
-          script_pubkey: key.script_pubkey,
-          value: 1,
-          status: :finalized,
-          key: key
-        )
-      end
-
-      it { is_expected.to eq key }
-    end
-
-    context 'utxo does not exist' do
-      it { is_expected.to be_nil}
-    end
-
-    context 'utxo is colored' do
-      let(:color_id) { Tapyrus::Color::ColorIdentifier.parse_from_payload('c185856a84c483fb108b1cdf79ff53aa7d54d1a137a5178684bd89ca31f906b2bd'.htb) }
-
-      before do
-        colored_script = Tapyrus::Script.parse_from_payload(key.script_pubkey.htb).add_color(color_id)
-        Glueby::Internal::Wallet::AR::Utxo.create(
-          txid: '0000000000000000000000000000000000000000000000000000000000000000',
-          index: 0,
-          script_pubkey: colored_script.to_hex,
-          value: 1,
-          status: :finalized,
-          key: key
-        )
-      end
-
-      it { is_expected.to eq key }
-    end
-  end
-
   describe '.key_for_output' do
     subject { Glueby::Internal::Wallet::AR::Key.key_for_output(output) }
 


### PR DESCRIPTION
This PR fixes the ActiveRecordWalletAdapter problem that fails to send a transaction when it uses colored utxo as an input.