### PR TITLE
Change the Payment.transfer argument to specify the Receiver's address

### DIFF
--- a/lib/glueby/contract/payment.rb
+++ b/lib/glueby/contract/payment.rb
@@ -11,6 +11,10 @@ module Glueby
     #                      or
     #            Glueby::Wallet.create
     #
+    # Use `Glueby::Internal::Wallet#receive_address` to generate the address of a receiver
+    # receiver.internal_wallet.receive_address
+    # => '1CY6TSSARn8rAFD9chCghX5B7j4PKR8S1a'
+    #
     # Balance of sender and receiver before send
     # sender.balances[""]
     # => 100_000(tapyrus)
@@ -18,7 +22,7 @@ module Glueby
     # => 0(tapyrus)
     #
     # Send
-    # Payment.transfer(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: 10_000)
+    # Payment.transfer(sender: sender, receiver_address: '1CY6TSSARn8rAFD9chCghX5B7j4PKR8S1a', amount: 10_000)
     # sender.balances[""]
     # => 90_000
     # receiver.balances[""]

--- a/lib/glueby/contract/payment.rb
+++ b/lib/glueby/contract/payment.rb
@@ -18,7 +18,7 @@ module Glueby
     # => 0(tapyrus)
     #
     # Send
-    # Payment.transfer(sender: sender, receiver: receiver, amount: 10_000)
+    # Payment.transfer(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: 10_000)
     # sender.balances[""]
     # => 90_000
     # receiver.balances[""]
@@ -28,7 +28,7 @@ module Glueby
       extend Glueby::Contract::TxBuilder
 
       class << self
-        def transfer(sender:, receiver:, amount:, fee_provider: FixedFeeProvider.new)
+        def transfer(sender:, receiver_address:, amount:, fee_provider: FixedFeeProvider.new)
           raise Glueby::Contract::Errors::InvalidAmount unless amount.positive?
 
           tx = Tapyrus::Tx.new
@@ -37,7 +37,7 @@ module Glueby
           sum, outputs = sender.internal_wallet.collect_uncolored_outputs(dummy_fee + amount)
           fill_input(tx, outputs)
 
-          receiver_script = Tapyrus::Script.parse_from_addr(receiver.internal_wallet.receive_address)
+          receiver_script = Tapyrus::Script.parse_from_addr(receiver_address)
           tx.outputs << Tapyrus::TxOut.new(value: amount, script_pubkey: receiver_script)
 
           fee = fee_provider.fee(tx)

--- a/spec/glueby/contract/payment_spec.rb
+++ b/spec/glueby/contract/payment_spec.rb
@@ -57,10 +57,10 @@ RSpec.describe 'Glueby::Contract::Payment' do
   end
 
   describe '#transfer' do
-    subject { Glueby::Contract::Payment.transfer(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: amount) }
+    subject { Glueby::Contract::Payment.transfer(sender: sender, receiver_address: receiver_address, amount: amount) }
 
     let(:sender) { wallet }
-    let(:receiver) { wallet }
+    let(:receiver_address) { wallet.internal_wallet.receive_address }
     let(:amount) { 200_000 }
 
     it { expect { subject }.not_to raise_error }
@@ -117,7 +117,7 @@ RSpec.describe 'Glueby::Contract::Payment' do
     end
 
     context 'does not have enough tpc because the fee is too high' do
-      subject { Glueby::Contract::Payment.transfer(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: amount, fee_provider: fee_provider) }
+      subject { Glueby::Contract::Payment.transfer(sender: sender, receiver_address: receiver_address, amount: amount, fee_provider: fee_provider) }
 
       let(:fee_provider) { Glueby::Contract::FixedFeeProvider.new(fixed_fee: 1_000_000_000) }
 

--- a/spec/glueby/contract/payment_spec.rb
+++ b/spec/glueby/contract/payment_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Glueby::Contract::Payment' do
   end
 
   describe '#transfer' do
-    subject { Glueby::Contract::Payment.transfer(sender: sender, receiver: receiver, amount: amount) }
+    subject { Glueby::Contract::Payment.transfer(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: amount) }
 
     let(:sender) { wallet }
     let(:receiver) { wallet }
@@ -117,7 +117,7 @@ RSpec.describe 'Glueby::Contract::Payment' do
     end
 
     context 'does not have enough tpc because the fee is too high' do
-      subject { Glueby::Contract::Payment.transfer(sender: sender, receiver: receiver, amount: amount, fee_provider: fee_provider) }
+      subject { Glueby::Contract::Payment.transfer(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: amount, fee_provider: fee_provider) }
 
       let(:fee_provider) { Glueby::Contract::FixedFeeProvider.new(fixed_fee: 1_000_000_000) }
 


### PR DESCRIPTION
The destination argument specified in Payment.trasfer was originally a Wallet object, but has been changed to specify an address.