### PR TITLE
broadcast tx by internal wallet in payment contract

### DIFF
--- a/lib/glueby/contract/payment.rb
+++ b/lib/glueby/contract/payment.rb
@@ -50,7 +50,7 @@ module Glueby
 
           tx = sender.internal_wallet.sign_tx(tx)
 
-          Glueby::Internal::RPC.client.sendrawtransaction(tx.to_hex)
+          sender.internal_wallet.broadcast(tx)
         end
       end
     end

--- a/spec/glueby/contract/payment_spec.rb
+++ b/spec/glueby/contract/payment_spec.rb
@@ -1,4 +1,6 @@
-RSpec.describe 'Glueby::Contract::Payment' do
+require 'active_record'
+
+RSpec.describe 'Glueby::Contract::Payment', active_record: true do
   let(:wallet) { TestWallet.new(internal_wallet) }
   let(:internal_wallet) { TestInternalWallet.new }
   let(:unspents) do
@@ -77,6 +79,17 @@ RSpec.describe 'Glueby::Contract::Payment' do
       subject
     end
 
+    context 'use active record wallet' do
+      let(:sender) { wallet }
+      let(:wallet) { TestWallet.new(internal_wallet) }
+      let(:internal_wallet) { TestInternalARWallet.new }
+      it do
+        expect(Glueby::Internal::Wallet::AR::Utxo.count).to eq(0)
+        subject
+        expect(Glueby::Internal::Wallet::AR::Utxo.count).to eq(1)
+      end
+    end
+    
     context 'invalid amount' do
       let(:amount) { 0 }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -127,6 +127,32 @@ class TestInternalWallet < Glueby::Internal::Wallet
   end
 end
 
+class TestInternalARWallet < Glueby::Internal::Wallet
+  def initialize; end
+
+  def receive_address
+    '1DBgMCNBdjQ1Ntz1vpwx2HMYJmc9kw88iT'
+  end
+
+  def change_address
+    '1LUMPgobnSdbaA4iaikHKjCDLHveWYUSt5'
+  end
+
+  def sign_tx(tx, _prevtxs = [])
+    tx
+  end
+
+  def broadcast(tx)
+    Glueby::Internal::Wallet::AR::Utxo.create(
+      txid: tx.txid,
+      index: 0,
+      script_pubkey: '76a9143f90406e69facde1c8b08ddd9cf3d41f69ff2c3b88ac',
+      value: 5_000_000_000,
+      status: :finalized
+    )
+  end
+end
+
 
 def setup_mock
   allow(Glueby::Internal::RPC).to receive(:client).and_return(rpc)
@@ -195,3 +221,4 @@ def setup_responses
   let(:response_getblockcount) { 2 }
   let(:response_getblockhash) { '022890167018b090211fb8ef26970c26a0cac6d29e5352f506dc31bbb84f3ce7' }
 end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -127,33 +127,6 @@ class TestInternalWallet < Glueby::Internal::Wallet
   end
 end
 
-class TestInternalARWallet < Glueby::Internal::Wallet
-  def initialize; end
-
-  def receive_address
-    '1DBgMCNBdjQ1Ntz1vpwx2HMYJmc9kw88iT'
-  end
-
-  def change_address
-    '1LUMPgobnSdbaA4iaikHKjCDLHveWYUSt5'
-  end
-
-  def sign_tx(tx, _prevtxs = [])
-    tx
-  end
-
-  def broadcast(tx)
-    Glueby::Internal::Wallet::AR::Utxo.create(
-      txid: tx.txid,
-      index: 0,
-      script_pubkey: '76a9143f90406e69facde1c8b08ddd9cf3d41f69ff2c3b88ac',
-      value: 5_000_000_000,
-      status: :finalized
-    )
-  end
-end
-
-
 def setup_mock
   allow(Glueby::Internal::RPC).to receive(:client).and_return(rpc)
   allow(rpc).to receive(:getblock).with('022890167018b090211fb8ef26970c26a0cac6d29e5352f506dc31bbb84f3ce7', 0).and_return(response_getblock)


### PR DESCRIPTION
When broadcasting Tx in Payment contract, I made a change using the broadcast method of internal_wallet how to use RPC.
This is to fix the bug that Utxo is not created when using the active_record wallet.