### PR TITLE
change response as issuing token

### DIFF
--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -73,7 +73,7 @@ module Glueby
                            raise Glueby::Contract::Errors::UnsupportedTokenType
                          end
           txs.each { |tx| issuer.internal_wallet.broadcast(tx) }
-          [new(color_id: color_id, script_pubkey: script_pubkey), txs[1]]
+          [new(color_id: color_id, script_pubkey: script_pubkey), txs]
         end
 
         private

--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -55,7 +55,7 @@ module Glueby
         # @param issuer [Glueby::Wallet]
         # @param token_type [TokenTypes]
         # @param amount [Integer]
-        # @return [Token] token
+        # @return [Array<token, Array<tx>>] Tuple of tx array and token object
         # @raise [InsufficientFunds] if wallet does not have enough TPC to send transaction.
         # @raise [InvalidAmount] if amount is not positive integer.
         # @raise [UnspportedTokenType] if token is not supported.
@@ -108,6 +108,7 @@ module Glueby
       # A wallet can issue the token only when it is REISSUABLE token.
       # @param issuer [Glueby::Wallet]
       # @param amount [Integer]
+      # @return [Array<String, tx>] Tuple of color_id and tx object
       # @raise [InsufficientFunds] if wallet does not have enough TPC to send transaction.
       # @raise [InvalidAmount] if amount is not positive integer.
       # @raise [InvalidTokenType] if token is not reissuable.
@@ -129,7 +130,7 @@ module Glueby
       # @param sender [Glueby::Wallet] wallet to send this token
       # @param receiver_address [String] address to receive this token
       # @param amount [Integer]
-      # @return [Token] receiver token
+      # @return [Array<String, tx>] Tuple of color_id and tx object
       # @raise [InsufficientFunds] if wallet does not have enough TPC to send transaction.
       # @raise [InsufficientTokens] if wallet does not have enough token to send.
       # @raise [InvalidAmount] if amount is not positive integer.

--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -73,7 +73,7 @@ module Glueby
                            raise Glueby::Contract::Errors::UnsupportedTokenType
                          end
           txs.each { |tx| issuer.internal_wallet.broadcast(tx) }
-          new(color_id: color_id, script_pubkey: script_pubkey)
+          [new(color_id: color_id, script_pubkey: script_pubkey), txs[1]]
         end
 
         private
@@ -121,6 +121,7 @@ module Glueby
         funding_tx = create_funding_tx(wallet: issuer, amount: estimated_fee, script: @script_pubkey)
         tx = create_reissue_tx(funding_tx: funding_tx, issuer: issuer, amount: amount, color_id: color_id)
         [funding_tx, tx].each { |tx| issuer.internal_wallet.broadcast(tx) }
+        [color_id, tx]
       end
 
       # Send the token to other wallet
@@ -137,6 +138,7 @@ module Glueby
 
         tx = create_transfer_tx(color_id: color_id, sender: sender, receiver_address: receiver_address, amount: amount)
         sender.internal_wallet.broadcast(tx)
+        [color_id, tx]
       end
 
       # Burn token

--- a/spec/glueby/contract/token_spec.rb
+++ b/spec/glueby/contract/token_spec.rb
@@ -68,9 +68,13 @@ RSpec.describe 'Glueby::Contract::Token' do
     let(:issuer) { wallet }
     let(:token_type) { Tapyrus::Color::TokenTypes::REISSUABLE }
     let(:amount) { 1_000 }
-
-    it { expect { subject }.not_to raise_error }
-    it { expect(subject.color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+    
+    it {
+      expect {subject}.not_to raise_error
+      expect(subject[0].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE
+      expect(subject[0].color_id.valid?).to be true
+      expect(subject[1].valid?).to be true
+    }
 
     context 'invalid amount' do
       let(:amount) { 0 }
@@ -92,13 +96,17 @@ RSpec.describe 'Glueby::Contract::Token' do
   end
 
   describe '#reissue!' do
-    subject { token.reissue!(issuer: issuer, amount: amount) }
+    subject { token[0].reissue!(issuer: issuer, amount: amount) }
 
     let(:token) { Glueby::Contract::Token.issue!(issuer: issuer) }
     let(:issuer) { wallet }
     let(:amount) { 1_000 }
 
-    it { expect { subject }.not_to raise_error }
+    it { 
+      expect { subject }.not_to raise_error
+      expect(subject[0].valid?).to be true
+      expect(subject[1].valid?).to be true
+    }
 
     context 'invalid amount' do
       let(:amount) { 0 }
@@ -133,7 +141,11 @@ RSpec.describe 'Glueby::Contract::Token' do
     let(:receiver_address) { wallet.internal_wallet.receive_address }
     let(:amount) { 200_000 }
 
-    it { expect { subject }.not_to raise_error }
+    it { 
+      expect { subject }.not_to raise_error
+      expect(subject[0].valid?).to be true
+      expect(subject[1].valid?).to be true
+    }
 
     context 'invalid amount' do
       let(:amount) { 0 }

--- a/spec/glueby/contract/token_spec.rb
+++ b/spec/glueby/contract/token_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'Glueby::Contract::Token' do
       expect {subject}.not_to raise_error
       expect(subject[0].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE
       expect(subject[0].color_id.valid?).to be true
-      expect(subject[1].valid?).to be true
+      expect(subject[1][1].valid?).to be true
     }
 
     context 'invalid amount' do


### PR DESCRIPTION
Changed issue token to return Token and Tupple of Tx object.
The transfer and reissue methods have been changed to return the required color_id and tx object according to the API documentation.