### PR TITLE
modify migration option

### DIFF
--- a/lib/glueby/generator/migrate_generator.rb
+++ b/lib/glueby/generator/migrate_generator.rb
@@ -28,7 +28,7 @@ module Glueby
 
       def table_options
         if mysql?
-          ', { options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" }'
+          ', :options => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"'
         else
           ""
         end


### PR DESCRIPTION
Changed the way the options for MySQL are written when using 'rails db:migrate'.