### PR TITLE
Make Glueby::Internal::Wallet.create_wallet  can get wallet_id 

### DIFF
--- a/glueby.gemspec
+++ b/glueby.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'tapyrus', '>= 0.2.6'
+  spec.add_runtime_dependency 'tapyrus', '>= 0.2.9'
   spec.add_development_dependency 'activerecord'
   spec.add_development_dependency 'sqlite3'
 end

--- a/lib/glueby/internal/wallet.rb
+++ b/lib/glueby/internal/wallet.rb
@@ -36,8 +36,13 @@ module Glueby
       class << self
         attr_writer :wallet_adapter
 
-        def create
-          new(wallet_adapter.create_wallet)
+        def create(wallet_id = nil)
+          begin
+            wallet_adapter.create_wallet(wallet_id)
+          rescue Errors::WalletAlreadyCreated => _
+            # Ignore when wallet is already created.
+          end
+          new(wallet_id)
         end
 
         def load(wallet_id)

--- a/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
@@ -7,8 +7,10 @@ module Glueby
       class AbstractWalletAdapter
         # Creates a new wallet inside the wallet component and returns `wallet_id`. The created
         # wallet is loaded from at first.
+        # @params [String] wallet_id - Option. The wallet id that if for the wallet to be created. If this is nil, wallet adapter generates it.
         # @return [String] wallet_id
-        def create_wallet
+        # @raise [Glueby::Internal::Wallet::Errors::WalletAlreadyCreated] when the specified wallet has been already created.
+        def create_wallet(wallet_id = nil)
           raise NotImplementedError, "You must implement #{self.class}##{__method__}"
         end
 

--- a/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
@@ -34,6 +34,7 @@ module Glueby
         #
         # @param [String] wallet_id - The wallet id that is offered by `create_wallet()` method.
         # @raise [Glueby::Internal::Wallet::Errors::WalletAlreadyLoaded] when the specified wallet has been already loaded.
+        # @raise [Glueby::Internal::Wallet::Errors::WalletNotFound] when the specified wallet is not found.
         def load_wallet(wallet_id)
           raise NotImplementedError, "You must implement #{self.class}##{__method__}"
         end

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -69,6 +69,7 @@ module Glueby
         end
 
         def load_wallet(wallet_id)
+          raise Errors::WalletNotFound, "Wallet #{wallet_id} does not found" unless AR::Wallet.where(wallet_id: wallet_id).exists?
         end
 
         def unload_wallet(wallet_id)

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -54,8 +54,7 @@ module Glueby
       # alice_wallet.balances
       # ```
       class ActiveRecordWalletAdapter < AbstractWalletAdapter
-        def create_wallet(wallet_id = nil)
-          wallet_id = SecureRandom.hex(16) unless wallet_id
+        def create_wallet(wallet_id = SecureRandom.hex(16))
           begin
             AR::Wallet.create!(wallet_id: wallet_id)
           rescue ActiveRecord::RecordInvalid => _

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -54,9 +54,13 @@ module Glueby
       # alice_wallet.balances
       # ```
       class ActiveRecordWalletAdapter < AbstractWalletAdapter
-        def create_wallet
-          wallet_id = SecureRandom.hex(16)
-          wallet = AR::Wallet.create(wallet_id: wallet_id)
+        def create_wallet(wallet_id = nil)
+          wallet_id = SecureRandom.hex(16) unless wallet_id
+          begin
+            AR::Wallet.create!(wallet_id: wallet_id)
+          rescue ActiveRecord::RecordInvalid => _
+            raise Errors::WalletAlreadyCreated, "wallet_id '#{wallet_id}' is already exists"
+          end
           wallet_id
         end
 

--- a/lib/glueby/internal/wallet/errors.rb
+++ b/lib/glueby/internal/wallet/errors.rb
@@ -6,6 +6,7 @@ module Glueby
         class WalletUnloaded < StandardError; end
         class WalletAlreadyLoaded < StandardError; end
         class WalletAlreadyCreated < StandardError; end
+        class WalletNotFound < StandardError; end
         class InvalidSighashType < StandardError; end
       end
     end

--- a/lib/glueby/internal/wallet/errors.rb
+++ b/lib/glueby/internal/wallet/errors.rb
@@ -5,6 +5,7 @@ module Glueby
         class ShouldInitializeWalletAdapter < StandardError; end
         class WalletUnloaded < StandardError; end
         class WalletAlreadyLoaded < StandardError; end
+        class WalletAlreadyCreated < StandardError; end
         class InvalidSighashType < StandardError; end
       end
     end

--- a/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
@@ -28,8 +28,7 @@ module Glueby
         RPC_WALLET_ERROR_ERROR_CODE = -4 # Unspecified problem with wallet (key not found etc.)
         RPC_WALLET_NOT_FOUND_ERROR_CODE = -18 # Invalid wallet specified
 
-        def create_wallet(wallet_id = nil)
-          wallet_id = SecureRandom.hex(16) unless wallet_id
+        def create_wallet(wallet_id = SecureRandom.hex(16))
           begin
             RPC.client.createwallet(wallet_name(wallet_id))
           rescue Tapyrus::RPC::Error => ex

--- a/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
@@ -56,6 +56,8 @@ module Glueby
           json = JSON.parse(ex.message)
           if json.is_a?(Hash) && json['code'] == RPC_WALLET_ERROR_ERROR_CODE && /Duplicate -wallet filename specified/ =~ ex.message
             raise Errors::WalletAlreadyLoaded, "Wallet #{wallet_id} has been already loaded."
+          elsif json.is_a?(Hash) && json['code'] == RPC_WALLET_NOT_FOUND_ERROR_CODE
+            raise Errors::WalletNotFound, "Wallet #{wallet_id} does not found"
           else
             raise ex
           end

--- a/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
@@ -32,9 +32,8 @@ module Glueby
           wallet_id = SecureRandom.hex(16) unless wallet_id
           begin
             RPC.client.createwallet(wallet_name(wallet_id))
-          rescue RuntimeError => ex
-            json = JSON.parse(ex.message)
-            if json.is_a?(Hash) && json['code'] == RPC_WALLET_ERROR_ERROR_CODE && /Wallet wallet-wallet already exists\./ =~ ex.message
+          rescue Tapyrus::RPC::Error => ex
+            if ex.rpc_error['code'] == RPC_WALLET_ERROR_ERROR_CODE && /Wallet wallet-wallet already exists\./ =~ ex.rpc_error['message']
               raise Errors::WalletAlreadyCreated, "Wallet #{wallet_id} has been already created."
             else
               raise ex
@@ -52,11 +51,10 @@ module Glueby
 
         def load_wallet(wallet_id)
           RPC.client.loadwallet(wallet_name(wallet_id))
-        rescue RuntimeError => ex
-          json = JSON.parse(ex.message)
-          if json.is_a?(Hash) && json['code'] == RPC_WALLET_ERROR_ERROR_CODE && /Duplicate -wallet filename specified/ =~ ex.message
+        rescue Tapyrus::RPC::Error => ex
+          if ex.rpc_error['code'] == RPC_WALLET_ERROR_ERROR_CODE && /Duplicate -wallet filename specified/ =~ ex.rpc_error['message']
             raise Errors::WalletAlreadyLoaded, "Wallet #{wallet_id} has been already loaded."
-          elsif json.is_a?(Hash) && json['code'] == RPC_WALLET_NOT_FOUND_ERROR_CODE
+          elsif ex.rpc_error['code'] == RPC_WALLET_NOT_FOUND_ERROR_CODE
             raise Errors::WalletNotFound, "Wallet #{wallet_id} does not found"
           else
             raise ex
@@ -150,9 +148,8 @@ module Glueby
           RPC.perform_as(wallet_name(wallet_id)) do |client|
             begin
               yield(client)
-            rescue RuntimeError => ex
-              json = JSON.parse(ex.message)
-              if json.is_a?(Hash) && json['code'] == RPC_WALLET_NOT_FOUND_ERROR_CODE
+            rescue Tapyrus::RPC::Error => ex
+              if ex.rpc_error['code'] == RPC_WALLET_NOT_FOUND_ERROR_CODE
                 raise Errors::WalletUnloaded, "The wallet #{wallet_id} is unloaded. You should load before use it."
               else
                 raise ex

--- a/spec/glueby/internal/wallet/active_record_wallet_adapter_spec.rb
+++ b/spec/glueby/internal/wallet/active_record_wallet_adapter_spec.rb
@@ -10,6 +10,25 @@ RSpec.describe 'Glueby::Internal::Wallet::ActiveRecordWalletAdapter', active_rec
     subject { adapter.create_wallet }
 
     it { expect { subject }.to change { Glueby::Internal::Wallet::AR::Wallet.count }.from(0).to(1) }
+
+    context 'specify wallet_id' do
+      subject { adapter.create_wallet('wallet') }
+
+      it 'create a new wallet with the wallet_id' do
+        expect { subject }.to change { Glueby::Internal::Wallet::AR::Wallet.count }.from(0).to(1)
+        expect(Glueby::Internal::Wallet::AR::Wallet.find_by(wallet_id: 'wallet')).not_to be_nil
+      end
+
+      context 'wallet_id is already exist' do
+        before do
+          adapter.create_wallet('wallet')
+        end
+
+        it 'raise an error' do
+          expect { subject }.to raise_error(error=Glueby::Internal::Wallet::Errors::WalletAlreadyCreated, message="wallet_id 'wallet' is already exists")
+        end
+      end
+    end
   end
 
   describe '#delete_wallet' do

--- a/spec/glueby/internal/wallet/active_record_wallet_adapter_spec.rb
+++ b/spec/glueby/internal/wallet/active_record_wallet_adapter_spec.rb
@@ -31,6 +31,28 @@ RSpec.describe 'Glueby::Internal::Wallet::ActiveRecordWalletAdapter', active_rec
     end
   end
 
+  describe '#load_wallet' do
+    subject { adapter.load_wallet(wallet_id) }
+
+    let(:wallet_id) { '0828d0ce8ff358cd0d7b19ac5c43c3bb' }
+
+    context 'wallet is exists' do
+      before do
+        adapter.create_wallet(wallet_id)
+      end
+
+      it 'never raise errors' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'wallet is not exists' do
+      it 'raise an error' do
+        expect { subject }.to raise_error(Glueby::Internal::Wallet::Errors::WalletNotFound, "Wallet #{wallet_id} does not found")
+      end
+    end
+  end
+
   describe '#delete_wallet' do
     it do
       wallet_id = adapter.create_wallet

--- a/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
+++ b/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
@@ -36,6 +36,31 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
       expect(rpc).to receive(:createwallet).and_return(response)
       subject
     end
+
+    context 'specify wallet_id' do
+      subject { adapter.create_wallet('wallet') }
+
+      let(:response) do
+        {
+          'name' => 'wallet-wallet',
+          'warning'=> ''
+        }
+      end
+
+      it 'create a new wallet with the wallet_id' do
+        expect(rpc).to receive(:createwallet).and_return(response)
+        subject
+      end
+
+      context 'wallet_id is already exist' do
+        let(:error) { RuntimeError.new('{"code": -4, "message": "Wallet wallet-wallet already exists."}') }
+
+        it 'raise an error' do
+          expect(rpc).to receive(:createwallet).and_raise(error)
+          expect { subject }.to raise_error(error=Glueby::Internal::Wallet::Errors::WalletAlreadyCreated, message="Wallet wallet has been already created.")
+        end
+      end
+    end
   end
 
   describe 'load_wallet' do

--- a/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
+++ b/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
@@ -1,8 +1,14 @@
 RSpec.shared_examples 'If the wallet is unloaded, it should raise WalletUnloaded error.' do
   let(:rpc_name) { :listunspent }
+  let(:error) do
+    Tapyrus::RPC::Error.new(
+      '500',
+      'Internal Server Error',
+      { 'code' => -18, 'message' => 'Requested wallet does not exist or is not loaded' }
+    )
+  end
   it 'should raise WalletUnloaded error.' do
-    expect(rpc).to receive(rpc_name)
-                     .and_raise(RuntimeError.new('{"code": -18, "message": "Requested wallet does not exist or is not loaded"}'))
+    expect(rpc).to receive(rpc_name).and_raise(error)
     expect { subject }
       .to raise_error(
         Glueby::Internal::Wallet::Errors::WalletUnloaded,
@@ -53,7 +59,13 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
       end
 
       context 'wallet_id is already exist' do
-        let(:error) { RuntimeError.new('{"code": -4, "message": "Wallet wallet-wallet already exists."}') }
+        let(:error) do
+          Tapyrus::RPC::Error.new(
+            '500',
+            'Internal Server Error',
+            { 'code' => -4, 'message' => 'Wallet wallet-wallet already exists.'}
+          )
+        end
 
         it 'raise an error' do
           expect(rpc).to receive(:createwallet).and_raise(error)
@@ -80,7 +92,13 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
     end
 
     context 'if already loaded' do
-      let(:error) { RuntimeError.new('{"code": -4, "message": "Wallet file verification failed: Error loading wallet wallet-0828d0ce8ff358cd0d7b19ac5c43c3bb. Duplicate -wallet filename specified."}') }
+      let(:error) do
+        Tapyrus::RPC::Error.new(
+          '500',
+          'Internal Server Error',
+          { 'code' => -4, 'message' => 'Wallet file verification failed: Error loading wallet wallet-0828d0ce8ff358cd0d7b19ac5c43c3bb. Duplicate -wallet filename specified.'}
+        )
+      end
 
       it do
         allow(rpc).to receive(:loadwallet).and_raise(error)
@@ -89,7 +107,13 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
     end
 
     context 'if not exists' do
-      let(:error) { RuntimeError.new("{\"code\":-18,\"message\":\"Wallet wallet-#{wallet_id} not found.\"}") }
+      let(:error) do
+        Tapyrus::RPC::Error.new(
+          '500',
+          'Internal Server Error',
+          { 'code' => -18, 'message' => "Wallet wallet-#{wallet_id} not found." }
+        )
+      end
 
       it do
         allow(rpc).to receive(:loadwallet).and_raise(error)

--- a/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
+++ b/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
@@ -87,6 +87,15 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
         expect { subject }.to raise_error Glueby::Internal::Wallet::Errors::WalletAlreadyLoaded
       end
     end
+
+    context 'if not exists' do
+      let(:error) { RuntimeError.new("{\"code\":-18,\"message\":\"Wallet wallet-#{wallet_id} not found.\"}") }
+
+      it do
+        allow(rpc).to receive(:loadwallet).and_raise(error)
+        expect { subject }.to raise_error(Glueby::Internal::Wallet::Errors::WalletNotFound, "Wallet #{wallet_id} does not found")
+      end
+    end
   end
 
   describe 'wallets' do

--- a/spec/glueby/internal/wallet_spec.rb
+++ b/spec/glueby/internal/wallet_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe 'Glueby::Internal::Wallet' do
 
       it { expect { subject }.to raise_error(Glueby::Internal::Wallet::Errors::ShouldInitializeWalletAdapter) }
     end
+
+    context 'if not exist' do
+      let(:error) { Glueby::Internal::Wallet::Errors::WalletNotFound }
+
+      it do
+        allow(Glueby::Internal::Wallet.wallet_adapter).to receive(:load_wallet).and_raise(error)
+        expect { subject }.to raise_error(Glueby::Internal::Wallet::Errors::WalletNotFound)
+      end
+    end
   end
 
   describe 'ShouldInitializeWalletAdapter Error' do

--- a/spec/glueby/wallet_spec.rb
+++ b/spec/glueby/wallet_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe 'Glueby::Wallet' do
   class TestWalletAdapter < Glueby::Internal::Wallet::AbstractWalletAdapter
-    def create_wallet; end
+    def create_wallet(wallet_id = nil); end
     def list_unspent(wallet_id, only_finalized = true)
       utxos = [
         {


### PR DESCRIPTION
In UTXO provider feature, the provider class object hold static wallet id as a constant and needs to 
use one internal wallet object that has the wallet id always. 

This PR add `wallet_id` argument to the internal wallet for it.

Also, `Glueby::Internal::Wallet.load` method can raise a WalletNotFound  error if the wallet is not exists. This behavior makes users to possible to create a new wallet againsts the wallet_id if the internal wallet fails to load.