### PR TITLE
Fixed uninitialized constant error when issuing tokens with core wallet

### DIFF
--- a/glueby.gemspec
+++ b/glueby.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'tapyrus', '>= 0.2.9'
-  spec.add_development_dependency 'activerecord'
+  spec.add_runtime_dependency 'activerecord'
   spec.add_development_dependency 'sqlite3'
 end

--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'activerecord'
+require 'active_record'
 
 module Glueby
   module Contract

--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'activerecord'
 
 module Glueby
   module Contract


### PR DESCRIPTION
Fixed a bug that `NameError (uninitialized constant #<Class:Glueby::Contract::Token>::ActiveRecord)` was displayed when issuing a token in core wallet.
Now it shows `ActiveRecord::StatementInvalid: Mysql2::Error::ConnectionError: Lost connection to MySQL server during query` error.