### PR TITLE
Fix glueby:fee_provider:manage_utxo_pool task.

### DIFF
--- a/lib/glueby/fee_provider/tasks.rb
+++ b/lib/glueby/fee_provider/tasks.rb
@@ -44,7 +44,7 @@ module Glueby
                 .fee(fee_provider.fixed_fee)
                 .build
         tx = wallet.sign_tx(tx)
-        wallet.broadcast(tx)
+        wallet.broadcast(tx, without_fee_provider: true)
       ensure
         status
       end

--- a/lib/glueby/internal/wallet.rb
+++ b/lib/glueby/internal/wallet.rb
@@ -99,8 +99,11 @@ module Glueby
         wallet_adapter.sign_tx(id, tx, prev_txs, sighashtype: sighashtype)
       end
 
-      def broadcast(tx)
-        tx = FeeProvider.provide(tx) if Glueby.configuration.fee_provider_bears?
+      # Broadcast a transaction via Tapyrus Core RPC
+      # @param [Tapyrus::Tx] tx The tx that would be broadcasted
+      # @option [Boolean] without_fee_provider The flag to avoid to use FeeProvider temporary.
+      def broadcast(tx, without_fee_provider: false)
+        tx = FeeProvider.provide(tx) if !without_fee_provider && Glueby.configuration.fee_provider_bears?
         wallet_adapter.broadcast(id, tx)
         tx
       end

--- a/spec/support/setup_fee_provider.rb
+++ b/spec/support/setup_fee_provider.rb
@@ -1,11 +1,11 @@
 RSpec.shared_context 'setup fee provider' do
   before do
+    Glueby.configuration.fee_provider_bears!
     # create UTXOs in the UTXO pool
     fee_provider = Glueby::FeeProvider.new
     wallet = fee_provider.wallet
     process_block(to_address: wallet.receive_address)
     Rake.application['glueby:fee_provider:manage_utxo_pool'].execute
-    Glueby.configuration.fee_provider_bears!
   end
 
   after do


### PR DESCRIPTION
The task was failure if FeeProvider is enabled and there are no UTXOs in the pool while executing the task.