### PR TITLE
Fix unexpected error when Tapyrus Core responds RPC error 

### DIFF
--- a/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
@@ -33,7 +33,7 @@ module Glueby
           begin
             RPC.client.createwallet(wallet_name(wallet_id))
           rescue Tapyrus::RPC::Error => ex
-            if ex.rpc_error['code'] == RPC_WALLET_ERROR_ERROR_CODE && /Wallet wallet-wallet already exists\./ =~ ex.rpc_error['message']
+            if ex.rpc_error && ex.rpc_error['code'] == RPC_WALLET_ERROR_ERROR_CODE && /Wallet wallet-#{wallet_id} already exists\./ =~ ex.rpc_error['message']
               raise Errors::WalletAlreadyCreated, "Wallet #{wallet_id} has been already created."
             else
               raise ex
@@ -52,9 +52,9 @@ module Glueby
         def load_wallet(wallet_id)
           RPC.client.loadwallet(wallet_name(wallet_id))
         rescue Tapyrus::RPC::Error => ex
-          if ex.rpc_error['code'] == RPC_WALLET_ERROR_ERROR_CODE && /Duplicate -wallet filename specified/ =~ ex.rpc_error['message']
+          if ex.rpc_error && ex.rpc_error['code'] == RPC_WALLET_ERROR_ERROR_CODE && /Duplicate -wallet filename specified/ =~ ex.rpc_error['message']
             raise Errors::WalletAlreadyLoaded, "Wallet #{wallet_id} has been already loaded."
-          elsif ex.rpc_error['code'] == RPC_WALLET_NOT_FOUND_ERROR_CODE
+          elsif ex.rpc_error && ex.rpc_error['code'] == RPC_WALLET_NOT_FOUND_ERROR_CODE
             raise Errors::WalletNotFound, "Wallet #{wallet_id} does not found"
           else
             raise ex
@@ -151,7 +151,7 @@ module Glueby
             begin
               yield(client)
             rescue Tapyrus::RPC::Error => ex
-              if ex.rpc_error['code'] == RPC_WALLET_NOT_FOUND_ERROR_CODE
+              if ex.rpc_error && ex.rpc_error['code'] == RPC_WALLET_NOT_FOUND_ERROR_CODE
                 raise Errors::WalletUnloaded, "The wallet #{wallet_id} is unloaded. You should load before use it."
               else
                 raise ex

--- a/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
+++ b/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
@@ -73,6 +73,15 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
         end
       end
 
+      context 'unauthenticated error' do
+        let(:error) { Tapyrus::RPC::Error.new('401', 'Unauthorized', nil) }
+
+        it 'raise an error' do
+          expect(rpc).to receive(:createwallet).and_raise(error)
+          expect { subject }.to raise_error(Tapyrus::RPC::Error, { response_code: '401', response_msg: 'Unauthorized' }.to_s)
+        end
+      end
+
       context 'as nil' do
         subject { adapter.create_wallet(nil) }
 
@@ -114,6 +123,15 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
       it do
         allow(rpc).to receive(:loadwallet).and_raise(error)
         expect { subject }.to raise_error Glueby::Internal::Wallet::Errors::WalletAlreadyLoaded
+      end
+    end
+
+    context 'unauthenticated error' do
+      let(:error) { Tapyrus::RPC::Error.new('401', 'Unauthorized', nil) }
+
+      it 'raise an error' do
+        expect(rpc).to receive(:loadwallet).and_raise(error)
+        expect { subject }.to raise_error(Tapyrus::RPC::Error, { response_code: '401', response_msg: 'Unauthorized' }.to_s)
       end
     end
 


### PR DESCRIPTION
This PR fixes the unexpected behavior occurred when Tapyrus Core RPC responds some error without 'rpc_error' field such as 'Unauthorized' error