### PR TITLE
fix list_unspent to get all unlabeled utxo

### DIFF
--- a/lib/glueby/internal/wallet.rb
+++ b/lib/glueby/internal/wallet.rb
@@ -82,6 +82,10 @@ module Glueby
         wallet_adapter.balance(id, only_finalized)
       end
 
+      # @param only_finalized [Boolean] The flag to get a UTXO with status only finalized
+      # @param label [String] This label is used to filtered the UTXOs with labeled if a key or Utxo is labeled.
+      #                    - If label is not specified (label=nil), all UTXOs will be returned.
+      #                    - If label=:unlabeled, only unlabeled UTXOs will be returned.
       def list_unspent(only_finalized = true, label = nil)
         wallet_adapter.list_unspent(id, only_finalized, label)
       end

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -93,7 +93,8 @@ module Glueby
           wallet = AR::Wallet.find_by(wallet_id: wallet_id)
           utxos = wallet.utxos
           utxos = utxos.where(status: :finalized) if only_finalized
-          utxos = utxos.where(label: label) if label
+          utxos = utxos.where(label: label) if label && (label != :unlabeled)
+          utxos = utxos.where(label: nil) if label == :unlabeled
           utxos.map do |utxo|
             {
               txid: utxo.txid,
@@ -121,7 +122,7 @@ module Glueby
 
         def receive_address(wallet_id, label = nil)
           wallet = AR::Wallet.find_by(wallet_id: wallet_id)
-          key = wallet.keys.create(purpose: :receive, label: label || '')
+          key = wallet.keys.create(purpose: :receive, label: label || nil)
           key.address
         end
 

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -122,7 +122,7 @@ module Glueby
 
         def receive_address(wallet_id, label = nil)
           wallet = AR::Wallet.find_by(wallet_id: wallet_id)
-          key = wallet.keys.create(purpose: :receive, label: label || nil)
+          key = wallet.keys.create(purpose: :receive, label: label)
           key.address
         end
 

--- a/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
@@ -88,7 +88,8 @@ module Glueby
             min_conf = only_finalized ? 1 : 0
             res = client.listunspent(min_conf)
 
-            res = res.filter { |i| i['label'] == label } if label
+            res = res.filter { |i| i['label'] == label } if label && (label != :unlabeled)
+            res = res.filter { |i| i['label'] == "" } if label == :unlabeled
  
             res.map do |i|
               script = Tapyrus::Script.parse_from_payload(i['scriptPubKey'].htb)

--- a/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
+++ b/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
@@ -311,6 +311,29 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
         ])
       end
     end
+
+    context 'with unlabeled' do
+      subject { adapter.list_unspent(wallet_id, true, :unlabeled) }
+      it 'should call listunspent RPC with label and parse the results.' do
+        expect(rpc).to receive(:listunspent).and_return(response)
+        expect(subject).to eq([{
+                                txid: "5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5",
+                                vout: 0,
+                                script_pubkey: "76a914234113b860822e68f9715d1957af28b8f5117ee288ac",
+                                color_id: nil,
+                                amount: 100000000,
+                                finalized: false
+                              },
+                               {
+                                 txid: "1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db",
+                                 vout: 1,
+                                 script_pubkey: "76a914234113b860822e68f9715d1957af28b8f5117ee288ac",
+                                 color_id: nil,
+                                 amount: 100000000,
+                                 finalized: true
+                               }])
+      end
+    end
   end
 
   describe 'sign_tx' do


### PR DESCRIPTION
This PR fixes the list_unspent method to get all unlabeled utxos by specifying ":unlabeled" as argument below.

```ruby
wallet.list_unspent(true, :unlabeled)
```