### PR TITLE
Fix #77

### DIFF
--- a/glueby.gemspec
+++ b/glueby.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'tapyrus', '>= 0.2.9'
-  spec.add_runtime_dependency 'activerecord'
+  spec.add_runtime_dependency 'activerecord', '~> 6.1.3.1'
   spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'rails', '~> 6.1.3.1'
 end

--- a/glueby.gemspec
+++ b/glueby.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'tapyrus', '>= 0.2.9'
-  spec.add_runtime_dependency 'activerecord', '~> 6.1.3.1'
+  spec.add_runtime_dependency 'activerecord', '~> 6.1.3'
   spec.add_development_dependency 'sqlite3'
-  spec.add_development_dependency 'rails', '~> 6.1.3.1'
+  spec.add_development_dependency 'rails', '~> 6.1.3'
 end

--- a/lib/glueby/contract/timestamp/syncer.rb
+++ b/lib/glueby/contract/timestamp/syncer.rb
@@ -7,6 +7,10 @@ module Glueby
             .where(txid: block.transactions.map(&:txid), status: :unconfirmed)
             .update_all(status: :confirmed)
         end
+
+        def self.enabled?
+          Glueby::Contract::AR::Timestamp.table_exists?
+        end
       end
     end
   end

--- a/lib/glueby/railtie.rb
+++ b/lib/glueby/railtie.rb
@@ -1,7 +1,7 @@
 module Glueby
   class Railtie < ::Rails::Railtie
     initializer "glueby.register_syncers" do
-      BlockSyncer.register_syncer(Contract::Timestamp::Syncer)
+      BlockSyncer.register_syncer(Contract::Timestamp::Syncer) if Contract::Timestamp::Syncer.enabled?
     end
 
     rake_tasks do

--- a/spec/glueby/railtie_spec.rb
+++ b/spec/glueby/railtie_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Glueby::Railtie', active_record: true do
+  require 'rails'
+  require 'glueby/railtie'
+  subject { Glueby::Railtie.initializers.each(&:run) }
+
+  it do
+    expect(Glueby::BlockSyncer).to receive(:register_syncer).with(Glueby::Contract::Timestamp::Syncer)
+    subject
+  end
+
+  context 'if glueby_timestamp table not created' do
+    before { ::ActiveRecord::Base.connection.drop_table :glueby_timestamps, if_exists: true }
+
+    it do
+      expect(Glueby::BlockSyncer).not_to receive(:register_syncer)
+      subject
+    end
+  end
+end


### PR DESCRIPTION
This PR will solve #77, and synchonize timestamp table only if activerecord feature is enabled and glueby_timestamps table has been created.