### PR TITLE
add only finalized option for collect_uncolored_outputs method

### DIFF
--- a/lib/glueby/internal/wallet.rb
+++ b/lib/glueby/internal/wallet.rb
@@ -132,8 +132,8 @@ module Glueby
         wallet_adapter.create_pubkey(id)
       end
 
-      def collect_uncolored_outputs(amount, label = nil)
-        utxos = list_unspent(true, label)
+      def collect_uncolored_outputs(amount, only_finalized = true, label = nil)
+        utxos = list_unspent(only_finalized, label)
 
         utxos.inject([0, []]) do |sum, output|
           next sum if output[:color_id]

--- a/lib/glueby/internal/wallet.rb
+++ b/lib/glueby/internal/wallet.rb
@@ -132,7 +132,7 @@ module Glueby
         wallet_adapter.create_pubkey(id)
       end
 
-      def collect_uncolored_outputs(amount, only_finalized = true, label = nil)
+      def collect_uncolored_outputs(amount, label = nil, only_finalized = true)
         utxos = list_unspent(only_finalized, label)
 
         utxos.inject([0, []]) do |sum, output|

--- a/spec/glueby/internal/wallet_spec.rb
+++ b/spec/glueby/internal/wallet_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Glueby::Internal::Wallet' do
   end
 
   describe 'collect_uncolored_outputs' do
-    before { allow(internal_wallet).to receive(:list_unspent).and_return(unspents) }
+    before { allow(internal_wallet).to receive(:list_unspent).and_return(finalized_unspents) }
 
     subject { wallet.internal_wallet.collect_uncolored_outputs(amount, nil, only_finalized) }
 
@@ -90,7 +90,7 @@ RSpec.describe 'Glueby::Internal::Wallet' do
           vout: 0,
           amount: 100_000_000,
           finalized: false
-        }, {
+        },{
           txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
           script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
           vout: 1,
@@ -130,11 +130,56 @@ RSpec.describe 'Glueby::Internal::Wallet' do
           color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
           amount: 100_000,
           finalized: true
-        },
+        }
+      ]
+    end
+    let(:finalized_unspents) do
+      [
+        {
+          txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
+          script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+          vout: 1,
+          amount: 100_000_000,
+          finalized: true
+        }, {
+          txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
+          script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+          vout: 2,
+          amount: 50_000_000,
+          finalized: true
+        }, {
+          txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
+          vout: 0,
+          script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
+          color_id: 'c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893',
+          amount: 1,
+          finalized: true
+        }, {
+          txid: 'f14b29639483da7c8d17b7b7515da4ff78b91b4b89434e7988ab1bc21ab41377',
+          vout: 0,
+          script_pubkey: '21c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016bc76a914fc688c091d91789ccda7a27bd8d88be9ae4af58e88ac',
+          color_id: 'c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016',
+          amount: 100_000,
+          finalized: true
+        }, {
+          txid: '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2',
+          vout: 0,
+          script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
+          amount: 100_000,
+          finalized: true
+        }, {
+          txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
+          vout: 2,
+          script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
+          amount: 100_000,
+          finalized: true
+        }
       ]
     end
 
-    it { expect(subject[0]).to eq 200_000_000 }
+    it { expect(subject[0]).to eq 150_000_000 }
     it { expect(subject[1].size).to eq 2 }
 
     context 'with unconfirmed' do

--- a/spec/glueby/internal/wallet_spec.rb
+++ b/spec/glueby/internal/wallet_spec.rb
@@ -76,9 +76,10 @@ RSpec.describe 'Glueby::Internal::Wallet' do
   describe 'collect_uncolored_outputs' do
     before { allow(internal_wallet).to receive(:list_unspent).and_return(unspents) }
 
-    subject { wallet.internal_wallet.collect_uncolored_outputs(amount) }
+    subject { wallet.internal_wallet.collect_uncolored_outputs(amount, only_finalized) }
 
     let(:amount) { 150_000_000 }
+    let(:only_finalized) { true }
     let(:wallet) { TestWallet.new(internal_wallet) }
     let(:internal_wallet) { TestInternalWallet.new }
     let(:unspents) do
@@ -129,12 +130,20 @@ RSpec.describe 'Glueby::Internal::Wallet' do
           color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
           amount: 100_000,
           finalized: true
-        }
+        },
       ]
     end
 
     it { expect(subject[0]).to eq 200_000_000 }
     it { expect(subject[1].size).to eq 2 }
+
+    context 'with unconfirmed' do
+      let(:amount) { 250_000_000 }
+      let(:only_finalized) { false }
+
+      it { expect(subject[0]).to eq 250_000_000 }
+      it { expect(subject[1].size).to eq 3 }
+    end
 
     context 'does not have enough tpc' do
       let(:amount) { 250_000_001 }

--- a/spec/glueby/internal/wallet_spec.rb
+++ b/spec/glueby/internal/wallet_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Glueby::Internal::Wallet' do
   describe 'collect_uncolored_outputs' do
     before { allow(internal_wallet).to receive(:list_unspent).and_return(unspents) }
 
-    subject { wallet.internal_wallet.collect_uncolored_outputs(amount, only_finalized) }
+    subject { wallet.internal_wallet.collect_uncolored_outputs(amount, nil, only_finalized) }
 
     let(:amount) { 150_000_000 }
     let(:only_finalized) { true }
@@ -141,8 +141,11 @@ RSpec.describe 'Glueby::Internal::Wallet' do
       let(:amount) { 250_000_000 }
       let(:only_finalized) { false }
 
-      it { expect(subject[0]).to eq 250_000_000 }
-      it { expect(subject[1].size).to eq 3 }
+      it do
+        expect(internal_wallet).to receive(:list_unspent).with(false, nil).and_return(unspents)
+        expect(subject[0]).to eq 250_000_000
+        expect(subject[1].size).to eq 3
+      end
     end
 
     context 'does not have enough tpc' do

--- a/spec/glueby/internal/wallet_spec.rb
+++ b/spec/glueby/internal/wallet_spec.rb
@@ -133,51 +133,7 @@ RSpec.describe 'Glueby::Internal::Wallet' do
         }
       ]
     end
-    let(:finalized_unspents) do
-      [
-        {
-          txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
-          script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
-          vout: 1,
-          amount: 100_000_000,
-          finalized: true
-        }, {
-          txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
-          script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
-          vout: 2,
-          amount: 50_000_000,
-          finalized: true
-        }, {
-          txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
-          vout: 0,
-          script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
-          color_id: 'c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893',
-          amount: 1,
-          finalized: true
-        }, {
-          txid: 'f14b29639483da7c8d17b7b7515da4ff78b91b4b89434e7988ab1bc21ab41377',
-          vout: 0,
-          script_pubkey: '21c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016bc76a914fc688c091d91789ccda7a27bd8d88be9ae4af58e88ac',
-          color_id: 'c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016',
-          amount: 100_000,
-          finalized: true
-        }, {
-          txid: '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2',
-          vout: 0,
-          script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
-          color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
-          amount: 100_000,
-          finalized: true
-        }, {
-          txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
-          vout: 2,
-          script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
-          color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
-          amount: 100_000,
-          finalized: true
-        }
-      ]
-    end
+    let(:finalized_unspents) { unspents.select{|i| i[:finalized]} }
 
     it { expect(subject[0]).to eq 150_000_000 }
     it { expect(subject[1].size).to eq 2 }


### PR DESCRIPTION
When setting the utxo for fee, etc., it is now possible to specify the status of the utxo to be retrieved as an option, as shown below.

手数料のためのutxoセットするなどの際、以下のように取得するutxoのstatusをオプションで指定できるようにしました。

```ruby
_, outputs = wallet.internal_wallet.(fee, true, :unlabeled)
```