### PR TITLE
Remove the address type argument of getnewaddress

### DIFF
--- a/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
@@ -23,7 +23,6 @@ module Glueby
         include Glueby::Internal::Wallet::TapyrusCoreWalletAdapter::Util
 
         WALLET_PREFIX = 'wallet-'
-        ADDRESS_TYPE = 'legacy'
 
         RPC_WALLET_ERROR_ERROR_CODE = -4 # Unspecified problem with wallet (key not found etc.)
         RPC_WALLET_NOT_FOUND_ERROR_CODE = -18 # Invalid wallet specified
@@ -127,19 +126,19 @@ module Glueby
 
         def receive_address(wallet_id, label = nil)
           perform_as(wallet_id) do |client|
-            client.getnewaddress(label || '', ADDRESS_TYPE)
+            client.getnewaddress(label || '')
           end
         end
 
         def change_address(wallet_id)
           perform_as(wallet_id) do |client|
-            client.getrawchangeaddress(ADDRESS_TYPE)
+            client.getrawchangeaddress
           end
         end
 
         def create_pubkey(wallet_id)
           perform_as(wallet_id) do |client|
-            address = client.getnewaddress('', ADDRESS_TYPE)
+            address = client.getnewaddress('')
             info = client.getaddressinfo(address)
             Tapyrus::Key.new(pubkey: info['pubkey'])
           end

--- a/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
+++ b/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
     let(:response) { 'mjRTJ97nY3zVuvspVQcCoKf3Q8zanVGF8g' }
 
     it 'should call getnewaddress RPC' do
-      expect(rpc).to receive(:getnewaddress).with('', 'legacy').and_return(response)
+      expect(rpc).to receive(:getnewaddress).with('').and_return(response)
       subject
     end
 
@@ -424,7 +424,7 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
       subject { adapter.receive_address(wallet_id, 'for tracking') }
 
       it 'should call getnewaddress RPC with label' do
-        expect(rpc).to receive(:getnewaddress).with('for tracking', 'legacy').and_return(response)
+        expect(rpc).to receive(:getnewaddress).with('for tracking').and_return(response)
         subject
       end
     end
@@ -437,7 +437,7 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
     let(:response) { 'mjRTJ97nY3zVuvspVQcCoKf3Q8zanVGF8g' }
 
     it 'should call getrawchangeaddress RPC' do
-      expect(rpc).to receive(:getrawchangeaddress).with('legacy').and_return(response)
+      expect(rpc).to receive(:getrawchangeaddress).and_return(response)
       subject
     end
 
@@ -479,7 +479,7 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
 
     it 'should call getnewaddress and getaddressinfo RPC and returns compressed pubkey.' do
       expect(rpc).to receive(:getnewaddress)
-                       .with('', 'legacy')
+                       .with('')
                        .and_return(getnewaddress_response)
       expect(rpc).to receive(:getaddressinfo)
                        .with(getnewaddress_response)


### PR DESCRIPTION
Remove the address type argument of getnewaddress due to the change of the RPC interface of Tapyrus Core

Fix #88