### PR TITLE
Make wallet adapter possible to execute blocks before actual broadcasting

### DIFF
--- a/lib/glueby/internal/wallet.rb
+++ b/lib/glueby/internal/wallet.rb
@@ -117,10 +117,7 @@ module Glueby
       # @param [Proc] block The block that is called before broadcasting. It can be used to handle tx that is modified by FeeProvider.
       def broadcast(tx, without_fee_provider: false, &block)
         tx = FeeProvider.provide(tx) if !without_fee_provider && Glueby.configuration.fee_provider_bears?
-
-        block.call(tx) if block
-
-        wallet_adapter.broadcast(id, tx)
+        wallet_adapter.broadcast(id, tx, &block)
         tx
       end
 

--- a/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
@@ -101,8 +101,10 @@ module Glueby
         #
         # @param [String] wallet_id - The wallet id that is offered by `create_wallet()` method.
         # @param [Tapyrus::Tx] tx - The transaction to be broadcasterd.
+        # @yield Option. If a block given, the block is called before actual broadcasting.
+        #   @yieldparam [Tapyrus::Tx] tx - The tx that is going to be broadcasted as is.
         # @return [String] txid
-        def broadcast(wallet_id, tx)
+        def broadcast(wallet_id, tx, &block)
           raise NotImplementedError, "You must implement #{self.class}##{__method__}"
         end
 

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -112,10 +112,11 @@ module Glueby
           wallet.sign(tx, prevtxs, sighashtype: sighashtype)
         end
 
-        def broadcast(wallet_id, tx)
+        def broadcast(wallet_id, tx, &block)
           ::ActiveRecord::Base.transaction do
             AR::Utxo.destroy_for_inputs(tx)
             AR::Utxo.create_or_update_for_outputs(tx, status: :broadcasted)
+            block.call(tx) if block
             Glueby::Internal::RPC.client.sendrawtransaction(tx.to_hex)
           end
         end

--- a/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
@@ -119,8 +119,9 @@ module Glueby
           end
         end
 
-        def broadcast(wallet_id, tx)
+        def broadcast(wallet_id, tx, &block)
           perform_as(wallet_id) do |client|
+            block.call(tx) if block
             client.sendrawtransaction(tx.to_hex)
           end
         end

--- a/spec/glueby/internal/wallet/active_record_wallet_adapter_spec.rb
+++ b/spec/glueby/internal/wallet/active_record_wallet_adapter_spec.rb
@@ -279,4 +279,28 @@ RSpec.describe 'Glueby::Internal::Wallet::ActiveRecordWalletAdapter', active_rec
       it { expect(subject.count).to eq 1 }
     end
   end
+
+  describe '#broadcast' do
+    subject { adapter.broadcast(wallet.wallet_id, tx) }
+    let(:tx) { Tapyrus::Tx.new }
+    let(:rpc) { double('mock') }
+
+    before do
+      allow(Glueby::Internal::RPC).to receive(:client).and_return(rpc)
+    end
+
+    it 'calls sendrawtransaction RPC' do
+      expect(Glueby::Internal::RPC.client).to receive(:sendrawtransaction).with(tx.to_hex)
+      subject
+    end
+
+    context 'given a block' do
+      it 'calls the block with tx that is in arguments' do
+        expect(Glueby::Internal::RPC.client).to receive(:sendrawtransaction).with(tx.to_hex)
+        adapter.broadcast(wallet.wallet_id, tx) do |tx_arg|
+          expect(tx).to eq tx_arg
+        end
+      end
+    end
+  end
 end

--- a/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
+++ b/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
@@ -491,4 +491,24 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
       let(:rpc_name) { :getnewaddress }
     end
   end
+
+  describe '#broadcast' do
+    subject { adapter.broadcast(wallet_id, tx) }
+    let(:tx) { Tapyrus::Tx.new }
+    let(:wallet_id) { ARBITRARY_WALLET_ID }
+
+    it 'calls sendrawtransaction RPC' do
+      expect(Glueby::Internal::RPC.client).to receive(:sendrawtransaction).with(tx.to_hex)
+      subject
+    end
+
+    context 'given a block' do
+      it 'calls the block with tx that is in arguments' do
+        expect(Glueby::Internal::RPC.client).to receive(:sendrawtransaction).with(tx.to_hex)
+        adapter.broadcast(wallet_id, tx) do |tx_arg|
+          expect(tx).to eq tx_arg
+        end
+      end
+    end
+  end
 end

--- a/spec/glueby/internal/wallet_spec.rb
+++ b/spec/glueby/internal/wallet_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'Glueby::Internal::Wallet' do
       end
     end
 
-    context 'A block argument is given' do
+    context 'A block argument is not given' do
       it 'doesnt pass the block to a wallet adapter' do
         expect(Glueby::Internal::Wallet.wallet_adapter)
           .to receive(:broadcast).with('created_wallet_id', tx) do |*args, &proc|

--- a/spec/glueby/internal/wallet_spec.rb
+++ b/spec/glueby/internal/wallet_spec.rb
@@ -73,6 +73,33 @@ RSpec.describe 'Glueby::Internal::Wallet' do
 
   end
 
+  describe 'broadcast' do
+    let(:tx) { Tapyrus::Tx.new }
+    let(:wallet) { Glueby::Internal::Wallet.create }
+
+    context 'A block argument is given' do
+      let(:block) { Proc.new {} }
+
+      it 'pass the block to a wallet adapter' do
+        expect(Glueby::Internal::Wallet.wallet_adapter)
+          .to receive(:broadcast).with('created_wallet_id', tx) do |*args, &proc|
+          expect(proc).to eq(block)
+        end
+        wallet.broadcast(tx, &block)
+      end
+    end
+
+    context 'A block argument is given' do
+      it 'doesnt pass the block to a wallet adapter' do
+        expect(Glueby::Internal::Wallet.wallet_adapter)
+          .to receive(:broadcast).with('created_wallet_id', tx) do |*args, &proc|
+          expect(proc).to be_nil
+        end
+        wallet.broadcast(tx)
+      end
+    end
+  end
+
   describe 'collect_uncolored_outputs' do
     before { allow(internal_wallet).to receive(:list_unspent).and_return(finalized_unspents) }
 


### PR DESCRIPTION
This is for the case of 
* Broadcasting has to be at the end of a database transaction process.  If broadcasting fails, the database transaction should roll back the transaction.
* A contract may want to get glueby_utxos.id and update own records with its use in one database transaction, in the case of ActiveRecordWalletAdapter. 