### PR TITLE
Change default list_unspent to protect labeled UTXOs

### DIFF
--- a/lib/glueby/internal/wallet.rb
+++ b/lib/glueby/internal/wallet.rb
@@ -84,8 +84,8 @@ module Glueby
 
       # @param only_finalized [Boolean] The flag to get a UTXO with status only finalized
       # @param label [String] This label is used to filtered the UTXOs with labeled if a key or Utxo is labeled.
-      #                    - If label is not specified (label=nil), all UTXOs will be returned.
-      #                    - If label=:unlabeled, only unlabeled UTXOs will be returned.
+      #                    - If label is not specified or label=:unlabeled, only unlabeled UTXOs will be returned.
+      #                    - If label=:all, all UTXOs will be returned.
       def list_unspent(only_finalized = true, label = nil)
         wallet_adapter.list_unspent(id, only_finalized, label)
       end

--- a/lib/glueby/internal/wallet.rb
+++ b/lib/glueby/internal/wallet.rb
@@ -84,9 +84,10 @@ module Glueby
 
       # @param only_finalized [Boolean] The flag to get a UTXO with status only finalized
       # @param label [String] This label is used to filtered the UTXOs with labeled if a key or Utxo is labeled.
-      #                    - If label is not specified or label=:unlabeled, only unlabeled UTXOs will be returned.
+      #                    - If label is nil or :unlabeled, only unlabeled UTXOs will be returned.
       #                    - If label=:all, all UTXOs will be returned.
-      def list_unspent(only_finalized = true, label = nil)
+      def list_unspent(only_finalized = true, label = :unlabeled)
+        label = :unlabeled unless label
         wallet_adapter.list_unspent(id, only_finalized, label)
       end
 

--- a/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
@@ -72,6 +72,8 @@ module Glueby
         # @param [Boolean] only_finalized - The UTXOs includes only finalized UTXO value if it
         #                                   is true. Default is true.
         # @param [String] label - Label for filtering UTXOs
+        #                       - If label is nil or :unlabeled, only unlabeled UTXOs will be returned.
+        #                       - If label=:all, it will return all utxos
         # @return [Array of UTXO]
         #
         # ## The UTXO structure

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -89,8 +89,6 @@ module Glueby
           utxos.sum(&:value)
         end
 
-        # If label=nil, it will return unlabeled utxos to protect labeled utxos for specific purpose
-        # If label=:all, it will return all utxos
         def list_unspent(wallet_id, only_finalized = true, label = nil)
           wallet = AR::Wallet.find_by(wallet_id: wallet_id)
           utxos = wallet.utxos

--- a/spec/functional/payment_spec.rb
+++ b/spec/functional/payment_spec.rb
@@ -9,14 +9,16 @@ RSpec.describe 'Payment Contract', functional: true do
     end
 
     context 'bear fees by sender' do
-      let(:sender)  { Glueby::Wallet.create }
-      let(:receiver) { Glueby::Wallet.create }
+      let!(:sender) { Glueby::Wallet.create }
+      let!(:receiver) { Glueby::Wallet.create }
       let(:before_balance) { sender.balances(false)[''] }
       let(:fee) { 10_000 }
       let(:fee_estimator) { Glueby::Contract::FixedFeeEstimator.new(fixed_fee: fee) }
 
       before do
         process_block(to_address: sender.internal_wallet.receive_address)
+        # create labeled utxo
+        process_block(to_address: receiver.internal_wallet.receive_address('labeled'))
         before_balance
       end
 
@@ -32,18 +34,23 @@ RSpec.describe 'Payment Contract', functional: true do
         expect(sender.balances(false)['']).to eq(before_balance - (10_000 + fee))
         # receiver got the sent amount
         expect(receiver.balances(false)['']).to eq(10_000)
+        # should not consume 'labeled' utxos
+        expect(receiver.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
+        expect(receiver.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
       end
     end
 
     context 'bear fees by UtxoProvider' do
       include_context 'setup fee provider'
 
-      let(:sender)  { Glueby::Wallet.create }
-      let(:receiver) { Glueby::Wallet.create }
+      let!(:sender) { Glueby::Wallet.create }
+      let!(:receiver) { Glueby::Wallet.create }
       let(:before_balance) { sender.balances(false)[''] }
 
       before do
         process_block(to_address: sender.internal_wallet.receive_address)
+        # create labeled utxo
+        process_block(to_address: receiver.internal_wallet.receive_address('labeled'))
         before_balance
       end
 
@@ -58,6 +65,9 @@ RSpec.describe 'Payment Contract', functional: true do
         expect(sender.balances(false)['']).to eq(before_balance - 10_000)
         # receiver got the sent amount
         expect(receiver.balances(false)['']).to eq(10_000)
+        # should not consume 'labeled' utxos
+        expect(receiver.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
+        expect(receiver.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
 
         sighashtype = tx.inputs[-1].script_sig.chunks.first.pushed_data[-1].unpack1('C')
         expect(sighashtype).to eq(Tapyrus::SIGHASH_TYPE[:all])

--- a/spec/functional/payment_spec.rb
+++ b/spec/functional/payment_spec.rb
@@ -15,14 +15,27 @@ RSpec.describe 'Payment Contract', functional: true do
       let(:fee) { 10_000 }
       let(:fee_estimator) { Glueby::Contract::FixedFeeEstimator.new(fixed_fee: fee) }
 
-      before do
-        process_block(to_address: sender.internal_wallet.receive_address)
-        # create labeled utxo
-        process_block(to_address: receiver.internal_wallet.receive_address('labeled'))
-        before_balance
-      end
-
       it 'pays TPC to another wallet' do
+        # create labeled utxo
+        process_block(to_address: sender.internal_wallet.receive_address('labeled'))
+
+        expect do
+          Glueby::Contract::Payment.transfer(
+            sender: sender,
+            receiver_address: receiver.internal_wallet.receive_address,
+            amount: 10_000,
+            fee_estimator: fee_estimator
+          )
+        end.to raise_error(Glueby::Contract::Errors::InsufficientFunds)
+
+        # should not consume 'labeled' utxos
+        expect(sender.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
+        expect(sender.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
+
+        # create a usable utxo for payment
+        process_block(to_address: sender.internal_wallet.receive_address)
+        before_balance
+
         Glueby::Contract::Payment.transfer(
           sender: sender,
           receiver_address: receiver.internal_wallet.receive_address,
@@ -35,8 +48,8 @@ RSpec.describe 'Payment Contract', functional: true do
         # receiver got the sent amount
         expect(receiver.balances(false)['']).to eq(10_000)
         # should not consume 'labeled' utxos
-        expect(receiver.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
-        expect(receiver.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
+        expect(sender.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
+        expect(sender.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
       end
     end
 
@@ -46,28 +59,41 @@ RSpec.describe 'Payment Contract', functional: true do
       let!(:sender) { Glueby::Wallet.create }
       let!(:receiver) { Glueby::Wallet.create }
       let(:before_balance) { sender.balances(false)[''] }
-
-      before do
-        process_block(to_address: sender.internal_wallet.receive_address)
-        # create labeled utxo
-        process_block(to_address: receiver.internal_wallet.receive_address('labeled'))
-        before_balance
-      end
+      let(:fixed_fee) { 1_000 }
 
       it 'pays TPC to another wallet' do
+        # create labeled utxo
+        process_block(to_address: sender.internal_wallet.receive_address('labeled'))
+
+        expect do
+          Glueby::Contract::Payment.transfer(
+            sender: sender,
+            receiver_address: receiver.internal_wallet.receive_address,
+            amount: 10_000
+          )
+        end.to raise_error(Glueby::Contract::Errors::InsufficientFunds)
+
+        # should not consume 'labeled' utxos
+        expect(sender.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
+        expect(sender.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000 + fixed_fee)
+
+        # create a usable utxo for payment
+        process_block(to_address: sender.internal_wallet.receive_address)
+        before_balance
+
         tx = Glueby::Contract::Payment.transfer(
           sender: sender,
           receiver_address: receiver.internal_wallet.receive_address,
           amount: 10_000
         )
 
-        # sender lose just sent amount.
+        # sender lose sent amount
         expect(sender.balances(false)['']).to eq(before_balance - 10_000)
         # receiver got the sent amount
         expect(receiver.balances(false)['']).to eq(10_000)
         # should not consume 'labeled' utxos
-        expect(receiver.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
-        expect(receiver.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
+        expect(sender.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
+        expect(sender.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000 + fixed_fee)
 
         sighashtype = tx.inputs[-1].script_sig.chunks.first.pushed_data[-1].unpack1('C')
         expect(sighashtype).to eq(Tapyrus::SIGHASH_TYPE[:all])

--- a/spec/functional/timestamp_spec.rb
+++ b/spec/functional/timestamp_spec.rb
@@ -13,13 +13,11 @@ RSpec.describe 'Timestamp Contract', functional: true do
     context 'bear fees by sender' do
       let(:fee) { 10_000 }
       let(:fee_estimator) { Glueby::Contract::FixedFeeEstimator.new(fixed_fee: fee) }
-      let!(:sender) { Glueby::Wallet.create }
+      let(:sender) { Glueby::Wallet.create }
       let(:before_balance) { sender.balances(false)[''] }
 
       before do
         process_block(to_address: sender.internal_wallet.receive_address)
-        # create labeled utxo
-        process_block(to_address: sender.internal_wallet.receive_address('labeled'))
         before_balance
       end
 
@@ -31,11 +29,8 @@ RSpec.describe 'Timestamp Contract', functional: true do
           fee_estimator: fee_estimator
         )
         timestamp.save!
-        
+
         expect(sender.balances(false)['']).to eq(before_balance - fee)
-        # should not consume 'labeled' utxos
-        expect(sender.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
-        expect(sender.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
       end
 
       it 'use rake task' do
@@ -62,10 +57,6 @@ RSpec.describe 'Timestamp Contract', functional: true do
         Rake.application['glueby:block_syncer:start'].execute
         ar.reload
         expect(ar.status).to eq('confirmed')
-
-        # should not consume 'labeled' utxos
-        expect(sender.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
-        expect(sender.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
       end
     end
 
@@ -74,13 +65,11 @@ RSpec.describe 'Timestamp Contract', functional: true do
 
       let(:fee) { 10_000 }
       let(:fee_estimator) { Glueby::Contract::FixedFeeEstimator.new(fixed_fee: fee) }
-      let!(:sender) { Glueby::Wallet.create }
+      let(:sender) { Glueby::Wallet.create }
       let(:before_balance) { sender.balances(false)[''] }
 
       before do
         process_block(to_address: sender.internal_wallet.receive_address)
-        # create labeled utxo
-        process_block(to_address: sender.internal_wallet.receive_address('labeled'))
         before_balance
       end
 
@@ -94,10 +83,6 @@ RSpec.describe 'Timestamp Contract', functional: true do
         timestamp.save!
 
         expect(sender.balances(false)['']).to eq(before_balance)
-
-        # should not consume 'labeled' utxos
-        expect(sender.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
-        expect(sender.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
       end
 
       it 'use rake task' do
@@ -124,10 +109,6 @@ RSpec.describe 'Timestamp Contract', functional: true do
         Rake.application['glueby:block_syncer:start'].execute
         ar.reload
         expect(ar.status).to eq('confirmed')
-
-        # should not consume 'labeled' utxos
-        expect(sender.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
-        expect(sender.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
       end
     end
   end

--- a/spec/functional/token_spec.rb
+++ b/spec/functional/token_spec.rb
@@ -11,13 +11,15 @@ RSpec.describe 'Token Contract', functional: true do
     context 'bear fees by sender' do
       let(:fee) { 10_000 }
       let(:fee_estimator) { Glueby::Contract::FixedFeeEstimator.new(fixed_fee: fee) }
-      let(:sender) { Glueby::Wallet.create }
-      let(:receiver) { Glueby::Wallet.create }
+      let!(:sender) { Glueby::Wallet.create }
+      let!(:receiver) { Glueby::Wallet.create }
       let(:before_balance) { sender.balances(false)[''] }
 
       before do
         process_block(to_address: sender.internal_wallet.receive_address)
         process_block(to_address: receiver.internal_wallet.receive_address)
+        # create labeled utxo
+        process_block(to_address: receiver.internal_wallet.receive_address('labeled'))
         before_balance
       end
 
@@ -51,6 +53,10 @@ RSpec.describe 'Token Contract', functional: true do
         expect(sender.balances(false)['']).to eq(before_balance - fee * 6)
         expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
 
+        # should not consume 'labeled' utxos
+        expect(receiver.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
+        expect(receiver.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
+
         # If the sending to Tapyrus Core is failure, Glueby::Contract::AR::ReissuableToken should not be created.
         TapyrusCoreContainer.stop
         begin
@@ -82,6 +88,10 @@ RSpec.describe 'Token Contract', functional: true do
 
         expect(sender.balances(false)['']).to eq(before_balance - fee * 3)
         expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+
+        # should not consume 'labeled' utxos
+        expect(receiver.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
+        expect(receiver.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
       end
 
       it 'NFT token' do
@@ -102,6 +112,10 @@ RSpec.describe 'Token Contract', functional: true do
         process_block
 
         expect(receiver.balances(false)[token.color_id.to_hex]).to be_nil
+
+        # should not consume 'labeled' utxos
+        expect(receiver.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
+        expect(receiver.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
       end
     end
 
@@ -110,14 +124,16 @@ RSpec.describe 'Token Contract', functional: true do
 
       let(:fee) { 10_000 }
       let(:fee_estimator) { Glueby::Contract::FixedFeeEstimator.new(fixed_fee: fee) }
-      let(:sender) { Glueby::Wallet.create }
-      let(:receiver) { Glueby::Wallet.create }
+      let!(:sender) { Glueby::Wallet.create }
+      let!(:receiver) { Glueby::Wallet.create }
       let(:before_balance) { sender.balances(false)[''] }
       let(:receiver_before_balance) { receiver.balances(false)[''] }
 
       before do
         process_block(to_address: sender.internal_wallet.receive_address)
         process_block(to_address: receiver.internal_wallet.receive_address)
+        # create labeled utxo
+        process_block(to_address: receiver.internal_wallet.receive_address('labeled'))
         before_balance
         receiver_before_balance
       end
@@ -148,6 +164,10 @@ RSpec.describe 'Token Contract', functional: true do
 
         expect(sender.balances(false)['']).to eq(before_balance)
         expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+
+        # should not consume 'labeled' utxos
+        expect(receiver.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
+        expect(receiver.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
       end
 
       it 'non-reissunable token' do
@@ -170,6 +190,10 @@ RSpec.describe 'Token Contract', functional: true do
 
         expect(sender.balances(false)['']).to eq(before_balance)
         expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+
+        # should not consume 'labeled' utxos
+        expect(receiver.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
+        expect(receiver.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
       end
 
       it 'NFT token' do
@@ -191,6 +215,10 @@ RSpec.describe 'Token Contract', functional: true do
 
         expect(receiver.balances(false)['']).to eq(receiver_before_balance)
         expect(receiver.balances(false)[token.color_id.to_hex]).to be_nil
+
+        # should not consume 'labeled' utxos
+        expect(receiver.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
+        expect(receiver.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
       end
     end
   end

--- a/spec/functional/token_spec.rb
+++ b/spec/functional/token_spec.rb
@@ -11,15 +11,13 @@ RSpec.describe 'Token Contract', functional: true do
     context 'bear fees by sender' do
       let(:fee) { 10_000 }
       let(:fee_estimator) { Glueby::Contract::FixedFeeEstimator.new(fixed_fee: fee) }
-      let!(:sender) { Glueby::Wallet.create }
-      let!(:receiver) { Glueby::Wallet.create }
+      let(:sender) { Glueby::Wallet.create }
+      let(:receiver) { Glueby::Wallet.create }
       let(:before_balance) { sender.balances(false)[''] }
 
       before do
         process_block(to_address: sender.internal_wallet.receive_address)
         process_block(to_address: receiver.internal_wallet.receive_address)
-        # create labeled utxo
-        process_block(to_address: receiver.internal_wallet.receive_address('labeled'))
         before_balance
       end
 
@@ -53,10 +51,6 @@ RSpec.describe 'Token Contract', functional: true do
         expect(sender.balances(false)['']).to eq(before_balance - fee * 6)
         expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
 
-        # should not consume 'labeled' utxos
-        expect(receiver.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
-        expect(receiver.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
-
         # If the sending to Tapyrus Core is failure, Glueby::Contract::AR::ReissuableToken should not be created.
         TapyrusCoreContainer.stop
         begin
@@ -88,10 +82,6 @@ RSpec.describe 'Token Contract', functional: true do
 
         expect(sender.balances(false)['']).to eq(before_balance - fee * 3)
         expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
-
-        # should not consume 'labeled' utxos
-        expect(receiver.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
-        expect(receiver.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
       end
 
       it 'NFT token' do
@@ -112,10 +102,6 @@ RSpec.describe 'Token Contract', functional: true do
         process_block
 
         expect(receiver.balances(false)[token.color_id.to_hex]).to be_nil
-
-        # should not consume 'labeled' utxos
-        expect(receiver.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
-        expect(receiver.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
       end
     end
 
@@ -124,16 +110,14 @@ RSpec.describe 'Token Contract', functional: true do
 
       let(:fee) { 10_000 }
       let(:fee_estimator) { Glueby::Contract::FixedFeeEstimator.new(fixed_fee: fee) }
-      let!(:sender) { Glueby::Wallet.create }
-      let!(:receiver) { Glueby::Wallet.create }
+      let(:sender) { Glueby::Wallet.create }
+      let(:receiver) { Glueby::Wallet.create }
       let(:before_balance) { sender.balances(false)[''] }
       let(:receiver_before_balance) { receiver.balances(false)[''] }
 
       before do
         process_block(to_address: sender.internal_wallet.receive_address)
         process_block(to_address: receiver.internal_wallet.receive_address)
-        # create labeled utxo
-        process_block(to_address: receiver.internal_wallet.receive_address('labeled'))
         before_balance
         receiver_before_balance
       end
@@ -164,10 +148,6 @@ RSpec.describe 'Token Contract', functional: true do
 
         expect(sender.balances(false)['']).to eq(before_balance)
         expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
-
-        # should not consume 'labeled' utxos
-        expect(receiver.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
-        expect(receiver.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
       end
 
       it 'non-reissunable token' do
@@ -190,10 +170,6 @@ RSpec.describe 'Token Contract', functional: true do
 
         expect(sender.balances(false)['']).to eq(before_balance)
         expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
-
-        # should not consume 'labeled' utxos
-        expect(receiver.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
-        expect(receiver.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
       end
 
       it 'NFT token' do
@@ -215,10 +191,6 @@ RSpec.describe 'Token Contract', functional: true do
 
         expect(receiver.balances(false)['']).to eq(receiver_before_balance)
         expect(receiver.balances(false)[token.color_id.to_hex]).to be_nil
-
-        # should not consume 'labeled' utxos
-        expect(receiver.internal_wallet.list_unspent(false, 'labeled').size).to eq(1)
-        expect(receiver.internal_wallet.list_unspent(false, 'labeled')[0][:amount]).to eq(5_000_000_000)
       end
     end
   end


### PR DESCRIPTION
Change `Glueby::Internal::Wallet#list_unspent`(collecting UTXOs functions) into getting unlabelled UTXOs by default to prevent labeled UTXOs from consuming for other purposes.

Fix #84