### PR TITLE
Fix signing timestamp transaction when using utxo provider

### DIFF
--- a/lib/glueby/contract/timestamp.rb
+++ b/lib/glueby/contract/timestamp.rb
@@ -41,8 +41,20 @@ module Glueby
             end
           end
 
+          prev_txs = if funding_tx
+            output = funding_tx.outputs.first
+            [{
+              txid: funding_tx.txid,
+              vout: 0,
+              scriptPubKey: output.script_pubkey.to_hex,
+              amount: output.value
+            }]
+          else
+            []
+          end
+
           txb.fee(fee).change_address(wallet.internal_wallet.change_address)
-          [funding_tx, wallet.internal_wallet.sign_tx(txb.build)]
+          [funding_tx, wallet.internal_wallet.sign_tx(txb.build, prev_txs)]
         end
 
         def get_transaction(tx)

--- a/lib/glueby/version.rb
+++ b/lib/glueby/version.rb
@@ -1,3 +1,3 @@
 module Glueby
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
Timestamp tx need "funding transaction" when  wallet uses Utxo provider.
In this case, timestamp tx should be signed with "prev_txs" parameter which is array of utxos in funding tx.