### PR TITLE
Refactor: extract method 'AR::Timestamp#save_with_broadcast'

### DIFF
--- a/lib/glueby.rb
+++ b/lib/glueby.rb
@@ -17,6 +17,16 @@ module Glueby
     require 'glueby/railtie'
   end
 
+  module GluebyLogger
+    def logger
+      if defined?(Rails)
+        Rails.logger
+      else
+        Logger.new(STDOUT)
+      end
+    end
+  end
+
   # Add prefix to activerecord table names
   def self.table_name_prefix
     'glueby_'

--- a/lib/glueby/contract/active_record/timestamp.rb
+++ b/lib/glueby/contract/active_record/timestamp.rb
@@ -3,6 +3,7 @@ module Glueby
     module AR
       class Timestamp < ::ActiveRecord::Base
         include Glueby::Contract::Timestamp::Util
+        include Glueby::Contract::TxBuilder
         enum status: { init: 0, unconfirmed: 1, confirmed: 2 }
         enum timestamp_type: { simple: 0, trackable: 1 }
 
@@ -20,6 +21,33 @@ module Glueby
         # Return true if timestamp type is 'trackable' and output in timestamp transaction has not been spent yet, otherwise return false.
         def latest
           trackable?
+        end
+
+        # Broadcast and save timestamp
+        # @param [Glueby::Contract::FixedFeeEstimator] fee estimator
+        # @return true if tapyrus transactions were broadcasted and the timestamp was updated successfully, otherwise false.
+        def save_with_broadcast(fee_estimator: Glueby::Contract::FixedFeeEstimator.new)
+          utxo_provider = Glueby::UtxoProvider.new if Glueby.configuration.use_utxo_provider?
+          wallet = Glueby::Wallet.load(wallet_id)
+          funding_tx, tx, p2c_address, payment_base = create_txs(wallet, prefix, content_hash, fee_estimator, utxo_provider, type: timestamp_type.to_sym)
+          if funding_tx
+            ::ActiveRecord::Base.transaction(joinable: false, requires_new: true) do
+              wallet.internal_wallet.broadcast(funding_tx)
+              logger.info("funding tx was broadcasted(id=#{id}, funding_tx.txid=#{funding_tx.txid})")
+            end
+          end
+          ::ActiveRecord::Base.transaction(joinable: false, requires_new: true) do
+            wallet.internal_wallet.broadcast(tx) do |tx|
+              assign_attributes(txid: tx.txid, status: :unconfirmed, p2c_address: p2c_address, payment_base: payment_base)
+              save!
+            end
+            logger.info("timestamp tx was broadcasted (id=#{id}, txid=#{tx.txid})")
+          end
+          true
+        rescue => e
+          logger.error("failed to broadcast (id=#{id}, reason=#{e.message})")
+          errors.add(:base, "failed to broadcast (id=#{id}, reason=#{e.message})")
+          false
         end
       end
     end

--- a/lib/glueby/contract/active_record/timestamp.rb
+++ b/lib/glueby/contract/active_record/timestamp.rb
@@ -2,8 +2,10 @@ module Glueby
   module Contract
     module AR
       class Timestamp < ::ActiveRecord::Base
+        include Glueby::GluebyLogger
         include Glueby::Contract::Timestamp::Util
         include Glueby::Contract::TxBuilder
+
         enum status: { init: 0, unconfirmed: 1, confirmed: 2 }
         enum timestamp_type: { simple: 0, trackable: 1 }
 

--- a/lib/glueby/contract/active_record/timestamp.rb
+++ b/lib/glueby/contract/active_record/timestamp.rb
@@ -24,7 +24,7 @@ module Glueby
         end
 
         # Broadcast and save timestamp
-        # @param [Glueby::Contract::FixedFeeEstimator] fee estimator
+        # @param [Glueby::Contract::FixedFeeEstimator] fee_estimator
         # @return true if tapyrus transactions were broadcasted and the timestamp was updated successfully, otherwise false.
         def save_with_broadcast(fee_estimator: Glueby::Contract::FixedFeeEstimator.new)
           utxo_provider = Glueby::UtxoProvider.new if Glueby.configuration.use_utxo_provider?

--- a/lib/glueby/contract/timestamp.rb
+++ b/lib/glueby/contract/timestamp.rb
@@ -81,14 +81,6 @@ module Glueby
         def get_transaction(tx)
           Glueby::Internal::RPC.client.getrawtransaction(tx.txid, 1)
         end
-
-        def logger
-          if defined?(Rails)
-            Rails.logger
-          else
-            Logger.new(STDOUT)
-          end
-        end
       end
       include Glueby::Contract::Timestamp::Util
 

--- a/lib/glueby/contract/timestamp.rb
+++ b/lib/glueby/contract/timestamp.rb
@@ -81,6 +81,14 @@ module Glueby
         def get_transaction(tx)
           Glueby::Internal::RPC.client.getrawtransaction(tx.txid, 1)
         end
+
+        def logger
+          if defined?(Rails)
+            Rails.logger
+          else
+            Logger.new(STDOUT)
+          end
+        end
       end
       include Glueby::Contract::Timestamp::Util
 

--- a/lib/glueby/version.rb
+++ b/lib/glueby/version.rb
@@ -1,3 +1,3 @@
 module Glueby
-  VERSION = "0.6.3"
+  VERSION = "0.6.4"
 end

--- a/lib/tasks/glueby/contract/timestamp.rake
+++ b/lib/tasks/glueby/contract/timestamp.rake
@@ -9,13 +9,7 @@ module Glueby
         def create
           timestamps = Glueby::Contract::AR::Timestamp.where(status: :init)
           fee_estimator = Glueby::Contract::FixedFeeEstimator.new
-          timestamps.each do |t|
-            begin
-              t.save_with_broadcast(fee_estimator: fee_estimator)
-            rescue => e
-              puts "failed to broadcast (id=#{t.id}, reason=#{e.message})"
-            end
-          end
+          timestamps.each { |t| t.save_with_broadcast(fee_estimator: fee_estimator) }
         end
       end
     end

--- a/spec/glueby/contract/timestamp/active_record/timestamp_spec.rb
+++ b/spec/glueby/contract/timestamp/active_record/timestamp_spec.rb
@@ -1,11 +1,12 @@
 
 RSpec.describe 'Glueby::Contract::AR::Timestamp', active_record: true do
+  let(:timestamp) do
+    Glueby::Contract::AR::Timestamp.create(wallet_id: '00000000000000000000000000000000', content: "\xFF\xFF\xFF", prefix: 'app', timestamp_type: timestamp_type)
+  end
+  let(:timestamp_type) { :simple }
+
   describe '#latest' do
     subject { timestamp.latest }
-
-    let(:timestamp) do
-      Glueby::Contract::AR::Timestamp.create(wallet_id: '00000000000000000000000000000000', content: "\xFF\xFF\xFF", prefix: 'app', timestamp_type: timestamp_type)
-    end
 
     context 'timestamp type is simple' do
       let(:timestamp_type) { :simple }
@@ -17,6 +18,99 @@ RSpec.describe 'Glueby::Contract::AR::Timestamp', active_record: true do
       let(:timestamp_type) { :trackable }
 
       it { is_expected.to be_truthy }
+    end
+  end
+
+  describe '#save_with_broadcast' do
+    subject { timestamp.save_with_broadcast }
+
+    let(:rpc) { double('mock') }
+    let(:wallet) { Glueby::Wallet.create }
+
+    let(:address) { wallet.internal_wallet.receive_address }
+    let(:key) do
+      Glueby::Internal::Wallet::AR::Key.find_by(script_pubkey: Tapyrus::Script.parse_from_addr(address).to_hex)
+    end
+
+    before do
+      Glueby.configuration.wallet_adapter = :activerecord
+      Glueby::Internal::Wallet::AR::Utxo.create(
+        txid: 'aa' * 32,
+        index: 0,
+        value: 20_000,
+        script_pubkey: '76a914f9cfb93abedaef5b725c986efb31cca730bc0b3d88ac',
+        status: :finalized,
+        key: key
+      )
+
+      allow(Glueby::Internal::RPC).to receive(:client).and_return(rpc)
+      allow(rpc).to receive(:sendrawtransaction).and_return('0000000000000000000000000000000000000000000000000000000000000000')
+      allow(rpc).to receive(:generatetoaddress).and_return('0000000000000000000000000000000000000000000000000000000000000000')
+      allow(Glueby::Wallet).to receive(:load).with("00000000000000000000000000000000").and_return(wallet)
+    end
+
+    after { Glueby::Internal::Wallet.wallet_adapter = nil }
+
+    it do
+      expect(rpc).to receive(:sendrawtransaction).once
+      subject
+    end
+
+    it do
+      subject
+      expect(timestamp.status).to eq "unconfirmed"
+      expect(timestamp.p2c_address).to be_nil
+      expect(timestamp.payment_base).to be_nil
+    end
+
+    context 'with trackable type' do
+      let(:timestamp_type) { :trackable }
+
+      it do
+        expect(rpc).to receive(:sendrawtransaction).once
+        subject
+      end
+
+      it do
+        subject
+        expect(timestamp.status).to eq "unconfirmed"
+        expect(timestamp.p2c_address).not_to be_nil
+        expect(timestamp.payment_base).not_to be_nil
+      end
+    end
+
+    context 'use utxo provider' do
+      let(:provider_wallet) do
+        Glueby::Internal::Wallet::AR::Wallet.create(wallet_id: Glueby::UtxoProvider::WALLET_ID)
+      end
+      let(:key) { provider_wallet.keys.create(purpose: :receive) }
+      let(:utxo_provider) { Glueby::UtxoProvider.new }
+
+      before do
+        Glueby.configuration.enable_utxo_provider!
+        Glueby::UtxoProvider.new
+
+        # 20 Utxos are pooled.
+        (0...21).each do |i|
+          Glueby::Internal::Wallet::AR::Utxo.create(
+            txid: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+            index: i,
+            script_pubkey: '76a91446c2fbfbecc99a63148fa076de58cf29b0bcf0b088ac',
+            key: key,
+            value: 1_000,
+            status: :finalized
+          )
+        end
+      end
+      after { Glueby.configuration.disable_utxo_provider! }
+
+      it do
+        expect(rpc).to receive(:sendrawtransaction).twice
+        subject
+        expect(timestamp.status).to eq "unconfirmed"
+        expect(timestamp.p2c_address).to be_nil
+        expect(timestamp.payment_base).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
This PR intends to extract the main codes in timestamp.rake as the method `AR::Timestamp#save_with_broadcast`