### PR TITLE
Implement Token#multi_transfer

### DIFF
--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -175,6 +175,18 @@ module Glueby
         [color_id, tx]
       end
 
+      def multi_transfer!(sender:, receivers:)
+        receivers.each do |r|
+          raise Glueby::Contract::Errors::InvalidAmount unless r[:amount].positive?
+        end
+        funding_tx = create_funding_tx(wallet: sender) if Glueby.configuration.use_utxo_provider?
+        funding_tx = sender.internal_wallet.broadcast(funding_tx) if funding_tx
+
+        tx = create_multi_transfer_tx(funding_tx: funding_tx, color_id: color_id, sender: sender, receivers: receivers)
+        sender.internal_wallet.broadcast(tx)
+        [color_id, tx]
+      end
+
       # Burn token
       # If amount is not specified or 0, burn all token associated with the wallet.
       #

--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -175,6 +175,14 @@ module Glueby
         [color_id, tx]
       end
 
+      # Send the tokens to multiple wallets
+      #
+      # @param sender [Glueby::Wallet] wallet to send this token
+      # @param receivers [Array<Hash>] array of hash, which keys are :address and :amount
+      # @return [Array<String, tx>] Tuple of color_id and tx object
+      # @raise [InsufficientFunds] if wallet does not have enough TPC to send transaction.
+      # @raise [InsufficientTokens] if wallet does not have enough token to send.
+      # @raise [InvalidAmount] if amount is not positive integer.
       def multi_transfer!(sender:, receivers:)
         receivers.each do |r|
           raise Glueby::Contract::Errors::InvalidAmount unless r[:amount].positive?

--- a/lib/glueby/version.rb
+++ b/lib/glueby/version.rb
@@ -1,3 +1,3 @@
 module Glueby
-  VERSION = "0.6.4"
+  VERSION = "0.7.0"
 end

--- a/spec/glueby/contract/token_spec.rb
+++ b/spec/glueby/contract/token_spec.rb
@@ -401,6 +401,109 @@ RSpec.describe 'Glueby::Contract::Token', active_record: true do
     end
   end
 
+  describe '#multi_transfer!' do
+    subject { token.multi_transfer!(sender: sender, receivers: receivers) }
+
+    let(:receivers) do
+      [
+        {
+          address: receiver_address, amount: amount
+        },{
+          address: another_address, amount: 1
+        }
+      ]
+    end
+    let(:token) { Glueby::Contract::Token.parse_from_payload('c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb376a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
+    let(:sender) { wallet }
+    let(:receiver_address) { wallet.internal_wallet.receive_address }
+    let(:another_address) { wallet.internal_wallet.receive_address }
+    let(:amount) { 199_999 }
+
+    it { 
+      expect { subject }.not_to raise_error
+      expect(subject[0].valid?).to be true
+      expect(subject[1].valid?).to be true
+    }
+
+    context 'use utxo provider', active_record: true do
+      let(:key) do
+        wallet = Glueby::Internal::Wallet::AR::Wallet.find_by(wallet_id: Glueby::UtxoProvider::WALLET_ID)
+        wallet.keys.create(purpose: :receive)
+      end
+
+      before do
+        Glueby::Internal::Wallet.wallet_adapter = Glueby::Internal::Wallet::ActiveRecordWalletAdapter.new
+        Glueby.configuration.enable_utxo_provider!
+        privider = Glueby::UtxoProvider.new
+
+        (0...20).each do |i|
+          Glueby::Internal::Wallet::AR::Utxo.create(
+            txid: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+            index: i,
+            script_pubkey: '76a91446c2fbfbecc99a63148fa076de58cf29b0bcf0b088ac',
+            key: key,
+            value: 1_000,
+            status: :finalized
+          )
+        end
+      end
+      after { Glueby.configuration.disable_utxo_provider! }
+
+      it do
+        expect(internal_wallet).to receive(:broadcast).twice
+        subject
+      end
+    end
+
+    context 'invalid amount' do
+      let(:amount) { 0 }
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InvalidAmount }
+    end
+
+    context 'does not have enough token' do
+      let(:amount) { 200_000 }
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InsufficientTokens }
+    end
+
+    context 'does not have enough tpc' do
+      let(:unspents) do
+        [{
+          txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
+          vout: 0,
+          script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
+          color_id: 'c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893',
+          amount: 1,
+          finalized: true
+        }, {
+          txid: 'f14b29639483da7c8d17b7b7515da4ff78b91b4b89434e7988ab1bc21ab41377',
+          vout: 0,
+          script_pubkey: '21c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016bc76a914fc688c091d91789ccda7a27bd8d88be9ae4af58e88ac',
+          color_id: 'c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016',
+          amount: 100_000,
+          finalized: true
+        }, {
+          txid: '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2',
+          vout: 0,
+          script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
+          amount: 100_000,
+          finalized: true
+        }, {
+          txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
+          vout: 2,
+          script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
+          amount: 100_000,
+          finalized: true
+        }]
+      end
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InsufficientFunds }
+    end
+  end
+
   describe '#burn!' do
     subject { token.burn!(sender: sender, amount: amount) }
 

--- a/spec/glueby/contract/tx_builder_spec.rb
+++ b/spec/glueby/contract/tx_builder_spec.rb
@@ -196,6 +196,7 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
     let(:color_id) { Tapyrus::Color::ColorIdentifier.parse_from_payload('c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3'.htb) }
     let(:sender) { wallet }
     let(:receiver_address) { wallet.internal_wallet.receive_address }
+    let(:script_pubkey) { Tapyrus::Script.parse_from_addr(receiver_address).add_color(color_id).to_hex }
     let(:amount) { 100_001 }
 
     it { expect(subject.inputs.size).to eq 3 }
@@ -209,6 +210,7 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
     it { expect(subject.outputs[0].value).to eq 100_001 }
     it { expect(subject.outputs[0].colored?).to be_truthy }
     it { expect(subject.outputs[0].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+    it { expect(subject.outputs[0].script_pubkey.to_hex).to eq script_pubkey }
     it { expect(subject.outputs[1].value).to eq 99_999 }
     it { expect(subject.outputs[1].colored?).to be_truthy }
     it { expect(subject.outputs[1].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
@@ -220,11 +222,17 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
 
     let(:color_id) { Tapyrus::Color::ColorIdentifier.parse_from_payload('c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3'.htb) }
     let(:sender) { wallet }
+    let(:address1) { wallet.internal_wallet.receive_address }
+    let(:address2) { wallet.internal_wallet.receive_address }
+    let(:address3) { wallet.internal_wallet.receive_address }
+    let(:script_pubkey1) { Tapyrus::Script.parse_from_addr(address1).add_color(color_id).to_hex }
+    let(:script_pubkey2) { Tapyrus::Script.parse_from_addr(address2).add_color(color_id).to_hex }
+    let(:script_pubkey3) { Tapyrus::Script.parse_from_addr(address3).add_color(color_id).to_hex }
     let(:receivers) do
       [
-        { address: wallet.internal_wallet.receive_address, amount: 100_001 },
-        { address: wallet.internal_wallet.receive_address, amount: 2 },
-        { address: wallet.internal_wallet.receive_address, amount: 3 }
+        { address: address1, amount: 100_001 },
+        { address: address2, amount: 2 },
+        { address: address3, amount: 3 }
       ]
     end
 
@@ -239,12 +247,15 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
     it { expect(subject.outputs[0].value).to eq 100_001 }
     it { expect(subject.outputs[0].colored?).to be_truthy }
     it { expect(subject.outputs[0].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+    it { expect(subject.outputs[0].script_pubkey.to_hex).to eq script_pubkey1 }
     it { expect(subject.outputs[1].value).to eq 2 }
     it { expect(subject.outputs[1].colored?).to be_truthy }
     it { expect(subject.outputs[1].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+    it { expect(subject.outputs[1].script_pubkey.to_hex).to eq script_pubkey2 }
     it { expect(subject.outputs[2].value).to eq 3 }
     it { expect(subject.outputs[2].colored?).to be_truthy }
     it { expect(subject.outputs[2].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+    it { expect(subject.outputs[2].script_pubkey.to_hex).to eq script_pubkey3 }
     it { expect(subject.outputs[3].value).to eq 99_994 }
     it { expect(subject.outputs[3].colored?).to be_truthy }
     it { expect(subject.outputs[3].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }

--- a/spec/glueby/contract/tx_builder_spec.rb
+++ b/spec/glueby/contract/tx_builder_spec.rb
@@ -215,6 +215,42 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
     it { expect(subject.outputs[2].value).to eq 99_990_000 }
   end
 
+  describe '#create_multi_transfer_tx' do
+    subject { mock.create_multi_transfer_tx(color_id: color_id, sender: sender, receivers: receivers) }
+
+    let(:color_id) { Tapyrus::Color::ColorIdentifier.parse_from_payload('c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3'.htb) }
+    let(:sender) { wallet }
+    let(:receivers) do
+      [
+        { address: wallet.internal_wallet.receive_address, amount: 100_001 },
+        { address: wallet.internal_wallet.receive_address, amount: 2 },
+        { address: wallet.internal_wallet.receive_address, amount: 3 }
+      ]
+    end
+
+    it { expect(subject.inputs.size).to eq 3 }
+    it { expect(subject.inputs[0].out_point.txid).to eq '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2' }
+    it { expect(subject.inputs[0].out_point.index).to eq 0 }
+    it { expect(subject.inputs[1].out_point.txid).to eq 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9' }
+    it { expect(subject.inputs[1].out_point.index).to eq 2 }
+    it { expect(subject.inputs[2].out_point.txid).to eq '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5' }
+    it { expect(subject.inputs[2].out_point.index).to eq 0 }
+    it { expect(subject.outputs.size).to eq 5 }
+    it { expect(subject.outputs[0].value).to eq 100_001 }
+    it { expect(subject.outputs[0].colored?).to be_truthy }
+    it { expect(subject.outputs[0].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+    it { expect(subject.outputs[1].value).to eq 2 }
+    it { expect(subject.outputs[1].colored?).to be_truthy }
+    it { expect(subject.outputs[1].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+    it { expect(subject.outputs[2].value).to eq 3 }
+    it { expect(subject.outputs[2].colored?).to be_truthy }
+    it { expect(subject.outputs[2].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+    it { expect(subject.outputs[3].value).to eq 99_994 }
+    it { expect(subject.outputs[3].colored?).to be_truthy }
+    it { expect(subject.outputs[3].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+    it { expect(subject.outputs[4].value).to eq 99_990_000 }
+  end
+
   describe '#create_burn_tx' do
     subject { mock.create_burn_tx(color_id: color_id, sender: sender, amount: amount, fee_estimator: fee_estimator) }
 


### PR DESCRIPTION
https://github.com/chaintope/tapyrus-api/issues/195 に関連して複数アドレスにトークンを送信するインターフェースを実装しています。