### PR TITLE
Add 'split' parameter to Token#issue and Token#reissue

### DIFF
--- a/lib/glueby/contract/errors.rb
+++ b/lib/glueby/contract/errors.rb
@@ -4,6 +4,7 @@ module Glueby
       class InsufficientFunds < StandardError; end
       class InsufficientTokens < StandardError; end
       class InvalidAmount < StandardError; end
+      class InvalidSplit < StandardError; end
       class InvalidTokenType < StandardError; end
       class InvalidTimestampType < StandardError; end
       class TxAlreadyBroadcasted < StandardError; end

--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -60,9 +60,11 @@ module Glueby
         # @return [Array<token, Array<tx>>] Tuple of tx array and token object
         # @raise [InsufficientFunds] if wallet does not have enough TPC to send transaction.
         # @raise [InvalidAmount] if amount is not positive integer.
+        # @raise [InvalidSplit] if split is greater than 1 for NFT token.
         # @raise [UnspportedTokenType] if token is not supported.
         def issue!(issuer:, token_type: Tapyrus::Color::TokenTypes::REISSUABLE, amount: 1, split: 1)
           raise Glueby::Contract::Errors::InvalidAmount unless amount.positive?
+          raise Glueby::Contract::Errors::InvalidSplit if token_type == Tapyrus::Color::TokenTypes::NFT && split > 1
 
           txs, color_id = case token_type
                          when Tapyrus::Color::TokenTypes::REISSUABLE

--- a/spec/glueby/contract/token_spec.rb
+++ b/spec/glueby/contract/token_spec.rb
@@ -63,11 +63,12 @@ RSpec.describe 'Glueby::Contract::Token', active_record: true do
   end
 
   describe '.issue!' do
-    subject { Glueby::Contract::Token.issue!(issuer: issuer, token_type: token_type, amount: amount) }
+    subject { Glueby::Contract::Token.issue!(issuer: issuer, token_type: token_type, amount: amount, split: split) }
 
     let(:issuer) { wallet }
     let(:token_type) { Tapyrus::Color::TokenTypes::REISSUABLE }
     let(:amount) { 1_000 }
+    let(:split) { 1 }
     
     context 'reissuable token' do
       it do
@@ -205,6 +206,13 @@ RSpec.describe 'Glueby::Contract::Token', active_record: true do
       let(:amount) { 0 }
 
       it { expect { subject }.to raise_error Glueby::Contract::Errors::InvalidAmount }
+    end
+
+    context 'invalid split' do
+      let(:split) { 2 }
+      let(:token_type) { Tapyrus::Color::TokenTypes::NFT }
+
+      it { expect { subject }.to raise_error Glueby::Contract::Errors::InvalidSplit }
     end
 
     context 'unsupported type' do

--- a/spec/glueby/contract/tx_builder_spec.rb
+++ b/spec/glueby/contract/tx_builder_spec.rb
@@ -149,6 +149,8 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
       it { expect(subject.outputs[2].colored?).to be_truthy }
       it { expect(subject.outputs[2].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
       it { expect(subject.outputs[3].value).to eq 99_990_000 }
+      it { expect(subject.outputs[0].script_pubkey).to eq subject.outputs[1].script_pubkey }
+      it { expect(subject.outputs[1].script_pubkey).to eq subject.outputs[2].script_pubkey }
     end
   end
 
@@ -182,6 +184,8 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
       it { expect(subject.outputs[2].colored?).to be_truthy }
       it { expect(subject.outputs[2].color_id.type).to eq Tapyrus::Color::TokenTypes::NON_REISSUABLE }
       it { expect(subject.outputs[3].value).to eq 99_990_000 }
+      it { expect(subject.outputs[0].script_pubkey).to eq subject.outputs[1].script_pubkey }
+      it { expect(subject.outputs[1].script_pubkey).to eq subject.outputs[2].script_pubkey }
     end
   end
 
@@ -237,6 +241,8 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
       it { expect(subject.outputs[2].colored?).to be_truthy }
       it { expect(subject.outputs[2].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
       it { expect(subject.outputs[3].value).to eq 99_990_000 }
+      it { expect(subject.outputs[0].script_pubkey).to eq subject.outputs[1].script_pubkey }
+      it { expect(subject.outputs[1].script_pubkey).to eq subject.outputs[2].script_pubkey }
     end
   end
   
@@ -399,6 +405,22 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
         expect(tx.outputs[0].script_pubkey.to_hex).to eq script_pubkey.to_hex
         expect(tx.outputs[9].value).to eq 1
         expect(tx.outputs[9].script_pubkey.to_hex).to eq script_pubkey.to_hex
+      end
+    end
+
+    context 'The amount is divisible by split.' do
+      let(:amount) { 999 }
+      let(:split) { 3 }
+
+      it do
+        subject 
+        expect(tx.outputs.size).to eq 3
+        expect(tx.outputs[0].value).to eq 333
+        expect(tx.outputs[0].script_pubkey.to_hex).to eq script_pubkey.to_hex
+        expect(tx.outputs[1].value).to eq 333
+        expect(tx.outputs[1].script_pubkey.to_hex).to eq script_pubkey.to_hex
+        expect(tx.outputs[2].value).to eq 333
+        expect(tx.outputs[2].script_pubkey.to_hex).to eq script_pubkey.to_hex
       end
     end
   end

--- a/spec/glueby/contract/tx_builder_spec.rb
+++ b/spec/glueby/contract/tx_builder_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
   end
 
   describe '#create_issue_tx_for_reissuable_token' do
-    subject { mock.create_issue_tx_for_reissuable_token(funding_tx: funding_tx, issuer: issuer, amount: amount) }
+    subject { mock.create_issue_tx_for_reissuable_token(funding_tx: funding_tx, issuer: issuer, amount: amount, split: split) }
 
     let(:funding_tx) do
       tx = Tapyrus::Tx.new
@@ -125,6 +125,7 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
     let(:script_pubkey) { Tapyrus::Script.parse_from_payload('76a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
     let(:issuer) { wallet }
     let(:amount) { 1_000 }
+    let(:split) { 1 }
 
     it { expect(subject.inputs.size).to eq 1 }
     it { expect(subject.inputs[0].out_point.txid).to eq funding_tx.txid }
@@ -134,13 +135,29 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
     it { expect(subject.outputs[0].colored?).to be_truthy }
     it { expect(subject.outputs[0].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
     it { expect(subject.outputs[1].value).to eq 99_990_000 }
+
+    context 'split outputs' do
+      let(:split) { 3 }
+      it { expect(subject.outputs.size).to eq 4 }
+      it { expect(subject.outputs[0].value).to eq 333 }
+      it { expect(subject.outputs[0].colored?).to be_truthy }
+      it { expect(subject.outputs[0].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+      it { expect(subject.outputs[1].value).to eq 333 }
+      it { expect(subject.outputs[1].colored?).to be_truthy }
+      it { expect(subject.outputs[1].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+      it { expect(subject.outputs[2].value).to eq 334 }
+      it { expect(subject.outputs[2].colored?).to be_truthy }
+      it { expect(subject.outputs[2].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+      it { expect(subject.outputs[3].value).to eq 99_990_000 }
+    end
   end
 
   describe '#create_issue_tx_for_non_reissuable_token' do
-    subject { mock.create_issue_tx_for_non_reissuable_token(issuer: issuer, amount: amount) }
+    subject { mock.create_issue_tx_for_non_reissuable_token(issuer: issuer, amount: amount, split: split) }
 
     let(:issuer) { wallet }
     let(:amount) { 1_000 }
+    let(:split) { 1 }
 
     it { expect(subject.inputs.size).to eq 1 }
     it { expect(subject.inputs[0].out_point.txid).to eq '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5' }
@@ -150,6 +167,22 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
     it { expect(subject.outputs[0].colored?).to be_truthy }
     it { expect(subject.outputs[0].color_id.type).to eq Tapyrus::Color::TokenTypes::NON_REISSUABLE }
     it { expect(subject.outputs[1].value).to eq 99_990_000 }
+
+    context 'split outputs' do
+      let(:split) { 3 }
+
+      it { expect(subject.outputs.size).to eq 4 }
+      it { expect(subject.outputs[0].value).to eq 333 }
+      it { expect(subject.outputs[0].colored?).to be_truthy }
+      it { expect(subject.outputs[0].color_id.type).to eq Tapyrus::Color::TokenTypes::NON_REISSUABLE }
+      it { expect(subject.outputs[1].value).to eq 333 }
+      it { expect(subject.outputs[1].colored?).to be_truthy }
+      it { expect(subject.outputs[1].color_id.type).to eq Tapyrus::Color::TokenTypes::NON_REISSUABLE }
+      it { expect(subject.outputs[2].value).to eq 334 }
+      it { expect(subject.outputs[2].colored?).to be_truthy }
+      it { expect(subject.outputs[2].color_id.type).to eq Tapyrus::Color::TokenTypes::NON_REISSUABLE }
+      it { expect(subject.outputs[3].value).to eq 99_990_000 }
+    end
   end
 
   describe '#create_issue_tx_for_nft_token' do
@@ -168,7 +201,7 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
   end
 
   describe '#create_reissue_tx' do
-    subject { mock.create_reissue_tx(funding_tx: funding_tx, issuer: issuer, amount: amount, color_id: color_id) }
+    subject { mock.create_reissue_tx(funding_tx: funding_tx, issuer: issuer, amount: amount, color_id: color_id, split: split) }
 
     let(:funding_tx) do
       tx = Tapyrus::Tx.new
@@ -179,6 +212,7 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
     let(:script_pubkey) { Tapyrus::Script.parse_from_payload('76a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
     let(:issuer) { wallet }
     let(:amount) { 1_000 }
+    let(:split) { 1 }
     let(:color_id) { Tapyrus::Color::ColorIdentifier.parse_from_payload('c185856a84c483fb108b1cdf79ff53aa7d54d1a137a5178684bd89ca31f906b2bd'.htb) }
 
     it { expect(subject.inputs.size).to eq 1 }
@@ -188,6 +222,22 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
     it { expect(subject.outputs[0].value).to eq 1_000 }
     it { expect(subject.outputs[0].colored?).to be_truthy }
     it { expect(subject.outputs[0].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+
+    context 'split outputs' do
+      let(:split) { 3 }
+
+      it { expect(subject.outputs.size).to eq 4 }
+      it { expect(subject.outputs[0].value).to eq 333 }
+      it { expect(subject.outputs[0].colored?).to be_truthy }
+      it { expect(subject.outputs[0].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+      it { expect(subject.outputs[1].value).to eq 333 }
+      it { expect(subject.outputs[1].colored?).to be_truthy }
+      it { expect(subject.outputs[1].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+      it { expect(subject.outputs[2].value).to eq 334 }
+      it { expect(subject.outputs[2].colored?).to be_truthy }
+      it { expect(subject.outputs[2].color_id.type).to eq Tapyrus::Color::TokenTypes::REISSUABLE }
+      it { expect(subject.outputs[3].value).to eq 99_990_000 }
+    end
   end
   
   describe '#create_transfer_tx' do
@@ -310,6 +360,48 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
     end
   end
 
+  describe '#add_split_output' do
+    subject { mock.add_split_output(tx, amount, split, script_pubkey) }
+
+    let(:tx) { Tapyrus::Tx.new }
+    let(:amount) { 10001 }
+    let(:split) { 1 }
+    let(:script_pubkey) { Tapyrus::Script.new }
+
+    it do
+      subject 
+      expect(tx.outputs.size).to eq 1
+      expect(tx.outputs[0].value).to eq 10001
+      expect(tx.outputs[0].script_pubkey.to_hex).to eq script_pubkey.to_hex
+    end
+
+    context 'split 100 outputs' do
+      let(:split) { 100 }
+
+      it do
+        subject 
+        expect(tx.outputs.size).to eq 100
+        expect(tx.outputs[0].value).to eq 100
+        expect(tx.outputs[0].script_pubkey.to_hex).to eq script_pubkey.to_hex
+        expect(tx.outputs[99].value).to eq 101
+        expect(tx.outputs[99].script_pubkey.to_hex).to eq script_pubkey.to_hex
+      end
+    end
+
+    context 'amount is less than split parameter' do
+      let(:amount) { 10 }
+      let(:split) { 100 }
+
+      it do
+        subject 
+        expect(tx.outputs.size).to eq 10
+        expect(tx.outputs[0].value).to eq 1
+        expect(tx.outputs[0].script_pubkey.to_hex).to eq script_pubkey.to_hex
+        expect(tx.outputs[9].value).to eq 1
+        expect(tx.outputs[9].script_pubkey.to_hex).to eq script_pubkey.to_hex
+      end
+    end
+  end
   describe '#fill_input' do
     subject { mock.fill_input(tx, outputs) }
 


### PR DESCRIPTION
This PR allows to create multiple outputs when issuing tokens and reissuring