### PR TITLE
Support transferring zero confirmed token

### DIFF
--- a/lib/glueby/active_record/system_information.rb
+++ b/lib/glueby/active_record/system_information.rb
@@ -6,6 +6,12 @@ module Glueby
         SystemInformation.find_by(info_key: "synced_block_number")
       end
 
+      # Return if wallet allows to use only finalized utxo.
+      # @return [Boolean] true if wallet allows to use only finalized utxo, otherwise false.
+      def self.use_only_finalized_utxo?
+        SystemInformation.find_by(info_key: "use_only_finalized_utxo")&.int_value != 0
+      end
+
       def int_value
         info_value.to_i
       end

--- a/lib/glueby/version.rb
+++ b/lib/glueby/version.rb
@@ -1,3 +1,3 @@
 module Glueby
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end

--- a/spec/functional/token_spec.rb
+++ b/spec/functional/token_spec.rb
@@ -103,6 +103,27 @@ RSpec.describe 'Token Contract', functional: true do
 
         expect(receiver.balances(false)[token.color_id.to_hex]).to be_nil
       end
+
+      context 'transfer unconfirmed token' do
+        it do
+          token, _txs = Glueby::Contract::Token.issue!(
+            issuer: sender, token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE, amount: 10_000)
+
+          expect(sender.balances(false)['']).to eq(before_balance - fee * 1)
+          expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
+
+          token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: 5_000, only_finalized: false)
+
+          expect(sender.balances(false)['']).to eq(before_balance - fee * 2)
+          expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
+          expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
+
+          token.burn!(sender: sender, amount: 5_000, only_finalized: false)
+
+          expect(sender.balances(false)['']).to eq(before_balance - fee * 3)
+          expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+        end
+      end
     end
 
     context 'bear fees by FeeProvider' do

--- a/spec/functional/token_spec.rb
+++ b/spec/functional/token_spec.rb
@@ -105,6 +105,12 @@ RSpec.describe 'Token Contract', functional: true do
       end
 
       context 'transfer unconfirmed token' do
+        before do
+          Glueby::AR::SystemInformation.create(
+            info_key: 'use_only_finalized_utxo',
+            info_value: '0'
+          )
+        end
         it do
           token, _txs = Glueby::Contract::Token.issue!(
             issuer: sender, token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE, amount: 10_000)
@@ -112,13 +118,13 @@ RSpec.describe 'Token Contract', functional: true do
           expect(sender.balances(false)['']).to eq(before_balance - fee * 1)
           expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
 
-          token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: 5_000, only_finalized: false)
+          token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: 5_000)
 
           expect(sender.balances(false)['']).to eq(before_balance - fee * 2)
           expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
           expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
 
-          token.burn!(sender: sender, amount: 5_000, only_finalized: false)
+          token.burn!(sender: sender, amount: 5_000)
 
           expect(sender.balances(false)['']).to eq(before_balance - fee * 3)
           expect(sender.balances(false)[token.color_id.to_hex]).to be_nil

--- a/spec/glueby/active_record/system_informations_spec.rb
+++ b/spec/glueby/active_record/system_informations_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Glueby::AR::SystemInformation', active_record: true do
   describe '.use_only_finalized_utxo?' do
     subject { Glueby::AR::SystemInformation.use_only_finalized_utxo? }
 
-    context 'default valueq' do
+    context 'default value' do
       it { expect(subject).to be_truthy }
     end
 

--- a/spec/glueby/active_record/system_informations_spec.rb
+++ b/spec/glueby/active_record/system_informations_spec.rb
@@ -25,6 +25,35 @@ RSpec.describe 'Glueby::AR::SystemInformation', active_record: true do
     it { expect(subject.info_value.to_i).to be 0 }
   end
 
+  describe '.use_only_finalized_utxo?' do
+    subject { Glueby::AR::SystemInformation.use_only_finalized_utxo? }
+
+    context 'default valueq' do
+      it { expect(subject).to be_truthy }
+    end
+
+    context 'if info_value is 0' do
+      before do
+        Glueby::AR::SystemInformation.create(
+          info_key: 'use_only_finalized_utxo',
+          info_value: '0'
+        )
+      end
+      it { expect(subject).to be_falsy }
+    end
+
+    context 'if info_value is 1' do
+      before do
+        Glueby::AR::SystemInformation.create(
+          info_key: 'use_only_finalized_utxo',
+          info_value: '1'
+        )
+      end
+
+      it { expect(subject).to be_truthy }
+    end
+  end
+
   describe '.int_value' do
     subject { Glueby::AR::SystemInformation.synced_block_height }
 

--- a/spec/glueby/contract/token_spec.rb
+++ b/spec/glueby/contract/token_spec.rb
@@ -642,7 +642,114 @@ RSpec.describe 'Glueby::Contract::Token', active_record: true do
 
     let(:token) { Glueby::Contract::Token.parse_from_payload('c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb376a914234113b860822e68f9715d1957af28b8f5117ee288ac'.htb) }
 
+    let(:unspents) do
+      [
+        {
+          txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
+          script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+          vout: 1,
+          amount: 100_000_000,
+          finalized: true
+        }, {
+          txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
+          script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+          vout: 2,
+          amount: 50_000_000,
+          finalized: true
+        }, {
+          txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
+          vout: 0,
+          script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
+          color_id: 'c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893',
+          amount: 1,
+          finalized: true
+        }, {
+          txid: 'f14b29639483da7c8d17b7b7515da4ff78b91b4b89434e7988ab1bc21ab41377',
+          vout: 0,
+          script_pubkey: '21c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016bc76a914fc688c091d91789ccda7a27bd8d88be9ae4af58e88ac',
+          color_id: 'c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016',
+          amount: 100_000,
+          finalized: true
+        }, {
+          txid: '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2',
+          vout: 0,
+          script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
+          amount: 100_000,
+          finalized: true
+        }, {
+          txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
+          vout: 2,
+          script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
+          amount: 100_000,
+          finalized: true
+        }
+      ]
+    end
     it { is_expected.to eq 200_000 }
+
+    context 'use unconfirmed utxo' do
+      before do
+        Glueby::AR::SystemInformation.create(
+          info_key: 'use_only_finalized_utxo',
+          info_value: '0'
+        )
+      end
+      let(:unspents) do
+        [
+          {
+            txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
+            script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+            vout: 1,
+            amount: 100_000_000,
+            finalized: true
+          }, {
+            txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
+            script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+            vout: 2,
+            amount: 50_000_000,
+            finalized: true
+          }, {
+            txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
+            vout: 0,
+            script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
+            color_id: 'c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893',
+            amount: 1,
+            finalized: true
+          }, {
+            txid: 'f14b29639483da7c8d17b7b7515da4ff78b91b4b89434e7988ab1bc21ab41377',
+            vout: 0,
+            script_pubkey: '21c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016bc76a914fc688c091d91789ccda7a27bd8d88be9ae4af58e88ac',
+            color_id: 'c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016',
+            amount: 100_000,
+            finalized: true
+          }, {
+            txid: '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2',
+            vout: 0,
+            script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+            color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
+            amount: 100_000,
+            finalized: true
+          }, {
+            txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
+            vout: 2,
+            script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+            color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
+            amount: 100_000,
+            finalized: true
+          }, {
+            txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
+            vout: 3,
+            script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+            color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
+            amount: 100_000,
+            finalized: false
+          }
+        ]
+      end
+      it { is_expected.to eq 300_000 }
+    end
   end
 
   describe '#color_id' do


### PR DESCRIPTION
system_informations テーブルに`use_only_finalized_utxo`をキーとして0(0-confirmedをふくむ)または1(confirmedなものだけ)を設定できるようにしました。