### PR TITLE
Adapt tapyrusrb 0.2.13

### DIFF
--- a/glueby.gemspec
+++ b/glueby.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'tapyrus', '>= 0.2.9'
+  spec.add_runtime_dependency 'tapyrus', '>= 0.2.13'
   spec.add_runtime_dependency 'activerecord', '~> 6.1.3'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'rails', '~> 6.1.3'

--- a/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
+++ b/spec/glueby/internal/wallet/tapyrus_core_wallet_adapter_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
 
         it 'raise an error' do
           expect(rpc).to receive(:createwallet).and_raise(error)
-          expect { subject }.to raise_error(Tapyrus::RPC::Error, { response_code: '401', response_msg: 'Unauthorized' }.to_s)
+          expect { subject }.to raise_error(Tapyrus::RPC::Error, { response_code: '401', response_msg: 'Unauthorized' }.to_json)
         end
       end
 
@@ -131,7 +131,7 @@ RSpec.describe 'Glueby::Internal::Wallet::TapyrusCoreWalletAdapter' do
 
       it 'raise an error' do
         expect(rpc).to receive(:loadwallet).and_raise(error)
-        expect { subject }.to raise_error(Tapyrus::RPC::Error, { response_code: '401', response_msg: 'Unauthorized' }.to_s)
+        expect { subject }.to raise_error(Tapyrus::RPC::Error, { response_code: '401', response_msg: 'Unauthorized' }.to_json)
       end
     end
 


### PR DESCRIPTION
tapyrusrb 0.2.13 changes type of Tapyrus::RPC::Errro#message to JSON string from ruby hash style string.