### PR TITLE
Add base error classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,11 @@ Glueby.configure do |config|
 end
 ```
 
+## Error handling
+
+Glueby has base error classes like `Glueby::Error` and `Glueby::ArgumentError`.
+`Glueby::Error` is the base class for the all errors that are raises in the glueby.
+`Glueby::ArgumentError` is the error class for argument errors in public contracts. This notifies the arguments is something wrong to glueby library user-side.
 
 ## Development
 

--- a/lib/glueby.rb
+++ b/lib/glueby.rb
@@ -48,4 +48,9 @@ module Glueby
   def self.configure
     yield configuration if block_given?
   end
+
+  # Base error classes. These error classes must be used as a super class in all error classes that is defined and
+  # raised in glueby library.
+  class Error < StandardError; end
+  class ArgumentError < Error; end
 end

--- a/lib/glueby/configuration.rb
+++ b/lib/glueby/configuration.rb
@@ -15,7 +15,7 @@ module Glueby
     alias_method :use_utxo_provider?, :use_utxo_provider
 
     module Errors
-      class InvalidConfiguration < StandardError; end
+      class InvalidConfiguration < Error; end
     end
 
     def initialize

--- a/lib/glueby/contract/errors.rb
+++ b/lib/glueby/contract/errors.rb
@@ -1,16 +1,18 @@
 module Glueby
   module Contract
     module Errors
-      class InsufficientFunds < StandardError; end
-      class InsufficientTokens < StandardError; end
-      class InvalidAmount < StandardError; end
-      class InvalidSplit < StandardError; end
-      class InvalidTokenType < StandardError; end
-      class InvalidTimestampType < StandardError; end
-      class TxAlreadyBroadcasted < StandardError; end
-      class UnsupportedTokenType < StandardError; end
-      class UnknownScriptPubkey < StandardError; end
-      class UnsupportedDigestType < StandardError; end
+      class InsufficientFunds < Error; end
+      class InsufficientTokens < Error; end
+      class TxAlreadyBroadcasted < Error; end
+
+      # Argument Errors
+      class InvalidAmount < ArgumentError; end
+      class InvalidSplit < ArgumentError; end
+      class InvalidTokenType < ArgumentError; end
+      class InvalidTimestampType < ArgumentError; end
+      class UnsupportedTokenType < ArgumentError; end
+      class UnknownScriptPubkey < ArgumentError; end
+      class UnsupportedDigestType < ArgumentError; end
     end
   end
 end

--- a/lib/glueby/fee_provider.rb
+++ b/lib/glueby/fee_provider.rb
@@ -3,7 +3,7 @@ module Glueby
 
     autoload :Tasks, 'glueby/fee_provider/tasks'
 
-    class NoUtxosInUtxoPool < StandardError; end
+    class NoUtxosInUtxoPool < Error; end
 
     WALLET_ID = 'FEE_PROVIDER_WALLET'
     DEFAULT_FIXED_FEE = 1000
@@ -42,7 +42,7 @@ module Glueby
     # Provide an input for fee to the tx.
     # @param [Tapyrus::Tx] tx - The tx that is provided fee as a input. It should be signed with ANYONECANPAY flag.
     # @return [Tapyrus::Tx]
-    # @raise [ArgumentError] If the signatures that the tx inputs has don't have ANYONECANPAY flag.
+    # @raise [Glueby::ArgumentError] If the signatures that the tx inputs has don't have ANYONECANPAY flag.
     # @raise [Glueby::FeeProvider::NoUtxosInUtxoPool] If there are no UTXOs for paying fee in FeeProvider's UTXO pool
     def provide(tx)
       tx.inputs.each do |txin|

--- a/lib/glueby/internal/wallet/errors.rb
+++ b/lib/glueby/internal/wallet/errors.rb
@@ -2,12 +2,12 @@ module Glueby
   module Internal
     class Wallet
       module Errors
-        class ShouldInitializeWalletAdapter < StandardError; end
-        class WalletUnloaded < StandardError; end
-        class WalletAlreadyLoaded < StandardError; end
-        class WalletAlreadyCreated < StandardError; end
-        class WalletNotFound < StandardError; end
-        class InvalidSighashType < StandardError; end
+        class ShouldInitializeWalletAdapter < Error; end
+        class WalletUnloaded < Error; end
+        class WalletAlreadyLoaded < Error; end
+        class WalletAlreadyCreated < Error; end
+        class WalletNotFound < Error; end
+        class InvalidSighashType < Error; end
       end
     end
   end

--- a/spec/glueby/contract/token_spec.rb
+++ b/spec/glueby/contract/token_spec.rb
@@ -762,7 +762,7 @@ RSpec.describe 'Glueby::Contract::Token', active_record: true do
     context 'with no script pubkey' do
       let(:token) { Glueby::Contract::Token.parse_from_payload('c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3'.htb) }
 
-      it { expect { subject }.to raise_error(ArgumentError, 'script_pubkey should not be empty') }
+      it { expect { subject }.to raise_error(Glueby::ArgumentError, 'script_pubkey should not be empty') }
     end
   end
 
@@ -780,7 +780,7 @@ RSpec.describe 'Glueby::Contract::Token', active_record: true do
       let(:token) { Glueby::Contract::Token.parse_from_payload('c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3'.htb) }
 
       it do
-        expect{ subject } .to raise_error(ArgumentError, 'script_pubkey should not be empty')
+        expect{ subject } .to raise_error(Glueby::ArgumentError, 'script_pubkey should not be empty')
         expect(Glueby::Contract::AR::ReissuableToken.count).to eq 0
       end
     end

--- a/spec/glueby/fee_provider_spec.rb
+++ b/spec/glueby/fee_provider_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Glueby::FeeProvider' do
       let(:tx) { Tapyrus::Tx.parse_from_payload("01000000018939a2974964f144941ed79c60a0046ee9f842f3b60453ea7d4533601c7ca030000000006a473044022004e5c255e7f397d3ea67e104b00bebfc31cff8d8f57b4c4972473936dda35d8e0220562676a1d1dfd85c89d596e7e96eaa178f8ef4b30c109c561612435137a8860401210280b5f253e612294a2c15a912bbb39b1d5ea48163c14bff56fd1a7079fed23258ffffffff02e8030000000000001976a91402b5fb1195e4c7b069ac33751d03d73a216babe588ac28230000000000001976a9148981ef639f525dc87b0c92ea9fb9af5148cf229688ac00000000".htb) }
 
       it 'raise ArgumentError' do
-        expect { subject }.to raise_error(ArgumentError, 'All the signatures that the tx inputs has should have ANYONECANPAY flag.')
+        expect { subject }.to raise_error(Glueby::ArgumentError, 'All the signatures that the tx inputs has should have ANYONECANPAY flag.')
       end
     end
   end


### PR DESCRIPTION
This adds `Glueby::Error` and `Glueby::ArgumentError` classes.

`Glueby::Error` is the base class for the all errors that are raises in the glueby.
`Glueby::ArgumentErrror` is the error class for arugument error in public contracts. This notifies the arguments is something wrong to glueby library user-side.