### PR TITLE
Remove autoload for non-existent file

### DIFF
--- a/lib/glueby/contract.rb
+++ b/lib/glueby/contract.rb
@@ -8,6 +8,5 @@ module Glueby
     autoload :Token, 'glueby/contract/token'
     autoload :TxBuilder, 'glueby/contract/tx_builder'
     autoload :AR, 'glueby/contract/active_record'
-    autoload :Wallet, 'glueby/contract/wallet'
   end
 end


### PR DESCRIPTION
`glueby/contract/wallet.rb` is not existent.

```
irb(main):004:0> Glueby::Contract::Wallet
/usr/local/bundle/gems/bootsnap-1.7.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require': cannot load such file -- glueby/contract/wallet (LoadError)
```