### PR TITLE
Set optional: true to Glueby::Contract::AR::Timestamp belongs_to prev

### DIFF
--- a/lib/glueby/contract/active_record/timestamp.rb
+++ b/lib/glueby/contract/active_record/timestamp.rb
@@ -9,7 +9,7 @@ module Glueby
 
         attr_reader :tx
 
-        belongs_to :prev, class_name: 'Glueby::Contract::AR::Timestamp'
+        belongs_to :prev, class_name: 'Glueby::Contract::AR::Timestamp', optional: true
 
         class << self
           def digest_content(content, digest)

--- a/spec/glueby/contract/timestamp/active_record/timestamp_spec.rb
+++ b/spec/glueby/contract/timestamp/active_record/timestamp_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Glueby::Contract::AR::Timestamp', active_record: true do
   end
 
   let(:timestamp) do
-    Glueby::Contract::AR::Timestamp.create(
+    Glueby::Contract::AR::Timestamp.create!(
       wallet_id: '00000000000000000000000000000000',
       content: "\xFF\xFF\xFF",
       prefix: 'app',
@@ -47,6 +47,21 @@ RSpec.describe 'Glueby::Contract::AR::Timestamp', active_record: true do
 
       it do
         expect { timestamp }.to raise_error(Glueby::ArgumentError, "'unknown' is not a valid timestamp_type")
+      end
+    end
+
+    context 'belongs_to required by default is true' do
+      before do
+        # From rails 6, true is the default value
+        ActiveRecord::Base.belongs_to_required_by_default = true
+      end
+
+      after do
+        ActiveRecord::Base.belongs_to_required_by_default = nil
+      end
+
+      it do
+        expect { timestamp }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
In Rails, ActiveRecord::Base.belongs_to_required_by_default is set as true, so without optional: true, the timestamp creation raise validation error with no prev_id.