### PR TITLE
Fix timestamp validation

### DIFF
--- a/lib/glueby/contract/active_record/timestamp.rb
+++ b/lib/glueby/contract/active_record/timestamp.rb
@@ -76,11 +76,11 @@ module Glueby
         # @return true if tapyrus transactions were broadcasted and the timestamp was updated successfully, otherwise false.
         def save_with_broadcast(fee_estimator: Glueby::Contract::FixedFeeEstimator.new, utxo_provider: nil)
           save_with_broadcast!(fee_estimator: fee_estimator, utxo_provider: utxo_provider)
-        rescue Errors::FailedToBroadcast,
-               Errors::PrevTimestampNotFound,
-               Errors::PrevTimestampIsNotTrackable,
-               Errors::PrevTimestampAlreadyUpdated => e
+        rescue Errors::FailedToBroadcast => e
           logger.error("failed to broadcast (id=#{id}, reason=#{e.message})")
+          false
+        rescue Errors::ArgumentError => e
+          logger.info("failed to broadcast by argument error (id=#{id}, reason=#{e.message})")
           false
         end
 
@@ -118,8 +118,7 @@ module Glueby
           end
           logger.info("timestamp tx was broadcasted (id=#{id}, txid=#{tx.txid})")
           true
-        rescue ActiveRecord::RecordInvalid,
-               Tapyrus::RPC::Error,
+        rescue Tapyrus::RPC::Error,
                Internal::Wallet::Errors::WalletAlreadyLoaded,
                Internal::Wallet::Errors::WalletNotFound,
                Errors::InsufficientFunds => e
@@ -176,10 +175,7 @@ module Glueby
         def validate_prev
           validate_prev!
           true
-        rescue Errors::PrevTimestampNotFound,
-               Errors::PrevTimestampIsNotTrackable,
-               Errors::UnnecessaryPrevTimestamp,
-               Errors::PrevTimestampAlreadyUpdated
+        rescue Errors::ArgumentError
           false
         end
 

--- a/lib/glueby/contract/active_record/timestamp.rb
+++ b/lib/glueby/contract/active_record/timestamp.rb
@@ -178,7 +178,8 @@ module Glueby
           true
         rescue Errors::PrevTimestampNotFound,
                Errors::PrevTimestampIsNotTrackable,
-               Errors::UnnecessaryPrevTimestamp
+               Errors::UnnecessaryPrevTimestamp,
+               Errors::PrevTimestampAlreadyUpdated
           false
         end
 

--- a/spec/glueby/contract/timestamp/active_record/timestamp_spec.rb
+++ b/spec/glueby/contract/timestamp/active_record/timestamp_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe 'Glueby::Contract::AR::Timestamp', active_record: true do
 
         it 'error' do
           expect { Glueby::Contract::AR::Timestamp.create!(valid_attributes.merge(prev_id: prev.id)) }
-            .to raise_error(Glueby::Contract::Errors::PrevTimestampAlreadyUpdated, /The previous timestamp\(id: [0-9]+\) was already updated/)
+            .to raise_error(ActiveRecord::RecordInvalid, /Validation failed: Prev The previous timestamp\(id: [0-9]+\) was already updated/)
         end
       end
 


### PR DESCRIPTION
It was raise Glueby::Contract::Errors::PrevTimestampAlreadyUpdated in where expects ActiveRecord::RecordInvalid

度々すいません :sweat_drops: 