### PR TITLE
Modify UtxoProvider#fill_inputs to set just minimum relay fee if it use FeeEstimator::Auto

### DIFF
--- a/lib/glueby/contract/fee_estimator.rb
+++ b/lib/glueby/contract/fee_estimator.rb
@@ -11,13 +11,20 @@ module Glueby
         estimate_fee(tx)
       end
 
-      # Add dummy inputs and outputs to tx
-      def dummy_tx(tx)
+      # Add dummy inputs and outputs to tx.
+      # Fee Estimation needs the actual tx size when it will be broadcasted to the blockchain network.
+      #
+      # @param [Tapyrus::Tx] tx The tx that is the target to be estimated fees
+      # @param [Integer] dummy_input_count The number of dummy inputs to be added before the estimation.
+      # @return [Tapyrus::Tx]
+      def dummy_tx(tx, dummy_input_count: 1)
         dummy = Tapyrus::Tx.parse_from_payload(tx.to_payload)
 
         # dummy input for tpc
-        out_point = Tapyrus::OutPoint.new('00' * 32, 0)
-        dummy.inputs << Tapyrus::TxIn.new(out_point: out_point)
+        dummy_input_count.times do
+          out_point = Tapyrus::OutPoint.new('00' * 32, 0)
+          dummy.inputs << Tapyrus::TxIn.new(out_point: out_point)
+        end
 
         # Add script_sig to all intpus
         dummy.inputs.each do |input|

--- a/lib/glueby/utxo_provider.rb
+++ b/lib/glueby/utxo_provider.rb
@@ -77,7 +77,7 @@ module Glueby
     # @return [Integer] current_amount The final amount of the tx inputs
     # @return [Array<Hash>] provided_utxos The utxos that are added to the tx inputs
     def fill_inputs(tx, target_amount: , current_amount: 0, fee_estimator: Contract::FeeEstimator::Fixed.new)
-      fee = fee_estimator.fee(Contract::FeeEstimator.dummy_tx(tx))
+      fee = fee_estimator.fee(Contract::FeeEstimator.dummy_tx(tx, dummy_input_count: 0))
       provided_utxos = []
 
       # If the change output value is less than DUST_LIMIT, tapyrus core returns "dust" error while broadcasting.
@@ -92,7 +92,7 @@ module Glueby
         end
         current_amount += sum
 
-        new_fee = fee_estimator.fee(Contract::FeeEstimator.dummy_tx(tx))
+        new_fee = fee_estimator.fee(Contract::FeeEstimator.dummy_tx(tx, dummy_input_count: 0))
         fee = new_fee
       end
 

--- a/spec/glueby/contract/fee_estimator_spec.rb
+++ b/spec/glueby/contract/fee_estimator_spec.rb
@@ -6,5 +6,11 @@ RSpec.describe 'Glueby::Contract::FeeEstimator' do
 
     it { expect(subject.inputs.size).to eq 1 }
     it { expect(subject.outputs.size).to eq 1 }
+
+    describe 'dummy_input_count: option' do
+      subject { Glueby::Contract::FeeEstimator.dummy_tx(Tapyrus::Tx.new, dummy_input_count: 2) }
+
+      it { expect(subject.inputs.size).to eq 2 }
+    end
   end
 end

--- a/spec/glueby/utxo_provider_spec.rb
+++ b/spec/glueby/utxo_provider_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe 'Glueby::UtxoProvider', active_record: true do
           allow(provider.wallet).to receive(:list_unspent).once.and_return(utxos)
           tx, fee, current_amount, provided_utxos = subject
           expect(tx.inputs.size).to eq(2)
-          expect(fee).to eq(501)
+          expect(fee).to eq(360)
           expect(current_amount).to eq(2_000)
           expect(provided_utxos).to contain_exactly(*utxos)
         end
@@ -119,7 +119,7 @@ RSpec.describe 'Glueby::UtxoProvider', active_record: true do
         it 'doesn\'t add inputs' do
           tx, fee, current_amount, provided_utxos = subject
           expect(tx.inputs.size).to eq(1)
-          expect(fee).to eq(360)
+          expect(fee).to eq(219)
           expect(current_amount).to eq(2_000)
           expect(provided_utxos).to be_empty
         end
@@ -141,7 +141,7 @@ RSpec.describe 'Glueby::UtxoProvider', active_record: true do
           allow(provider.wallet).to receive(:list_unspent).once.and_return(utxos)
           tx, fee, current_amount, provided_utxos = subject
           expect(tx.inputs.size).to eq(2)
-          expect(fee).to eq(501)
+          expect(fee).to eq(360)
           expect(current_amount).to eq(2_000)
           expect(provided_utxos).to contain_exactly(*utxos)
         end
@@ -157,7 +157,7 @@ RSpec.describe 'Glueby::UtxoProvider', active_record: true do
           expect(provider.wallet).to receive(:list_unspent).twice.and_return(utxos)
           tx, fee, current_amount, provided_utxos = subject
           expect(tx.inputs.size).to eq(12)
-          expect(fee).to eq(1_911)
+          expect(fee).to eq(1_770)
           expect(current_amount).to eq(12_000)
           expect(provided_utxos).to contain_exactly(*utxos)
         end


### PR DESCRIPTION
FeeEstiamtor.dummy_tx は常に 1 つのダミー input を追加していたので、その input が不要な場合、その input 分の余計な手数料を負担する tx を作成していました。

このPRでは、追加するダミー input をオプションで指定できるように dummy_tx を拡張しています。これにより不要な場合は 0 を指定することで、余計な手数量の増加を防ぎます。