### PR TITLE
Support ruby 3.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0"]
+        ruby-version: ["2.6", "2.7", "3.0", "3.1"]
 
     steps:
       - run: docker pull tapyrus/tapyrusd:v0.5.1
@@ -26,8 +26,7 @@ jobs:
       - name: Set up Ruby
         # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
         # change this to (see https://github.com/ruby/setup-ruby#versioning):
-        # uses: ruby/setup-ruby@v1
-        uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/glueby.gemspec
+++ b/glueby.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'tapyrus', '>= 0.2.13'
+  spec.add_runtime_dependency 'tapyrus', '>= 0.3.1'
   spec.add_runtime_dependency 'activerecord', '~> 6.1.3'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'rails', '~> 6.1.3'


### PR DESCRIPTION
Applying the following modification to tapyrusrb will make it work with Ruby 3.1:

https://github.com/chaintope/tapyrusrb/releases/tag/v0.3.1