### PR TITLE
Raise error when the wallet has no private key associated with trackable timestamp

### DIFF
--- a/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
@@ -170,6 +170,7 @@ module Glueby
         # @param [Integer] sighashtype - The sighash flag for each signature that would be produced here.
         # @return [Tapyrus::Tx]
         # @raise [Glueby::Internal::Wallet::Errors::InvalidSighashType] when the specified sighashtype is invalid
+        # @raise [Glueby::Internal::Wallet::Errors::InvalidSigner] when the wallet don't have any private key of the specified payment_base
         def sign_to_pay_to_contract_address(wallet_id, tx, utxo, payment_base, contents, sighashtype: Tapyrus::SIGHASH_TYPE[:all])
           raise NotImplementedError, "You must implement #{self.class}##{__method__}"
         end

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -190,10 +190,13 @@ module Glueby
         # @param [String] payment_base The public key hex string
         # @param [String] contents
         # @return [Tapyrus::Key] pay to contract private key
+        # @raise [Errors::InvalidSigner] raises when the wallet don't have any private key of the specified payment_base
         def create_pay_to_contract_private_key(wallet_id, payment_base, contents)
           group = ECDSA::Group::Secp256k1
           wallet = AR::Wallet.find_by(wallet_id: wallet_id)
           ar_key = wallet.keys.where(public_key: payment_base).first
+          raise Errors::InvalidSigner, "The wallet don't have any private key of the specified payment_base" unless ar_key
+
           key = Tapyrus::Key.new(pubkey: payment_base)
           commitment = create_pay_to_contract_commitment(key, contents)
           Tapyrus::Key.new(priv_key: ((ar_key.private_key.to_i(16) + commitment) % group.order).to_even_length_hex) # K + commitment

--- a/lib/glueby/internal/wallet/errors.rb
+++ b/lib/glueby/internal/wallet/errors.rb
@@ -8,6 +8,7 @@ module Glueby
         class WalletAlreadyCreated < Error; end
         class WalletNotFound < Error; end
         class InvalidSighashType < Error; end
+        class InvalidSigner < Error; end
       end
     end
   end


### PR DESCRIPTION
Trackableなタイムスタンプを発行後、他のウォレットを使って更新しようとした場合に、 `Glueby::Internal::Wallet::Errors::InvalidSigner` をraiseするようにしました。

