### PR TITLE
Remove burn_all_amount_flag in create_burn_tx

### DIFF
--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -306,9 +306,7 @@ module Glueby
         raise Glueby::Contract::Errors::InsufficientTokens unless balance
         raise Glueby::Contract::Errors::InsufficientTokens if balance < amount
 
-        burn_all_amount_flag = true if balance - amount == 0
-
-        tx = create_burn_tx(color_id: color_id, sender: sender, amount: amount, only_finalized: only_finalized?, fee_estimator: fee_estimator, burn_all_amount: burn_all_amount_flag)
+        tx = create_burn_tx(color_id: color_id, sender: sender, amount: amount, only_finalized: only_finalized?, fee_estimator: fee_estimator)
         sender.internal_wallet.broadcast(tx)
       end
 

--- a/spec/glueby/contract/token_spec.rb
+++ b/spec/glueby/contract/token_spec.rb
@@ -566,6 +566,22 @@ RSpec.describe 'Glueby::Contract::Token', active_record: true do
         end
       end
 
+      context 'If the token amount and fee is equal to value in utxos' do
+        let(:amount) { 100_000 }
+        let(:fee_estimator) { Glueby::Contract::FeeEstimator::Fixed.new(fixed_fee: 401) }
+
+        it 'has one output for to be a standard tx' do
+          expect(internal_wallet).to receive(:broadcast).once do |tx|
+            # Need 1_001 tapyrus at least, that means 401 tapyrus for tx fee, and 600 tapyrus to avoiding "dust limit error"
+            # 1 colored input(100_000 token), 2 uncolored inputs(1_000 * 2 tapyrus)
+            expect(tx.inputs.count).to eq 3
+            expect(tx.outputs.count).to eq(1)
+            expect(tx.outputs[0].value).to eq(1_599)
+          end
+          subject
+        end
+      end
+
       context 'use Auto fee estimator' do
         let(:fee_estimator) { Glueby::Contract::FeeEstimator::Auto.new }
 


### PR DESCRIPTION
When burning all tokens in one utxo, UtxoProvider#fill_inputs method provides an extra output with a DUST_LIMIT value.
In this case, we doesn't need burn_all_amount_flag in create_burn_tx method.