### PR TITLE
Add validation to check if the wallet which updates timestamp is same as one which creates it

### DIFF
--- a/lib/glueby/contract/active_record/timestamp.rb
+++ b/lib/glueby/contract/active_record/timestamp.rb
@@ -121,6 +121,7 @@ module Glueby
         rescue Tapyrus::RPC::Error,
                Internal::Wallet::Errors::WalletAlreadyLoaded,
                Internal::Wallet::Errors::WalletNotFound,
+               Glueby::Internal::Wallet::Errors::InvalidSigner,
                Errors::InsufficientFunds => e
           errors.add(:base, "failed to broadcast (id=#{id}, reason=#{e.message})")
           raise Errors::FailedToBroadcast, "failed to broadcast (id=#{id}, reason=#{e.message})"
@@ -209,7 +210,7 @@ module Glueby
           if prev.wallet_id != wallet_id
             message = "The previous timestamp(id: #{prev_id}) was created by the different user"
             errors.add(:prev_id, message)
-            raise Errors::InvalidWallet, message
+            raise Glueby::Internal::Wallet::Errors::InvalidSigner, message
           end
         end
       end

--- a/lib/glueby/contract/active_record/timestamp.rb
+++ b/lib/glueby/contract/active_record/timestamp.rb
@@ -205,6 +205,12 @@ module Glueby
             errors.add(:prev_id, message)
             raise Errors::PrevTimestampAlreadyUpdated, message
           end
+
+          if prev.wallet_id != wallet_id
+            message = "The previous timestamp(id: #{prev_id}) was created by the different user"
+            errors.add(:prev_id, message)
+            raise Errors::InvalidWallet, message
+          end
         end
       end
     end

--- a/lib/glueby/contract/errors.rb
+++ b/lib/glueby/contract/errors.rb
@@ -12,6 +12,7 @@ module Glueby
       class InvalidSplit < ArgumentError; end
       class InvalidTokenType < ArgumentError; end
       class InvalidTimestampType < ArgumentError; end
+      class InvalidWallet < ArgumentError; end
       class UnsupportedTokenType < ArgumentError; end
       class UnknownScriptPubkey < ArgumentError; end
       class UnsupportedDigestType < ArgumentError; end

--- a/lib/glueby/contract/errors.rb
+++ b/lib/glueby/contract/errors.rb
@@ -12,7 +12,6 @@ module Glueby
       class InvalidSplit < ArgumentError; end
       class InvalidTokenType < ArgumentError; end
       class InvalidTimestampType < ArgumentError; end
-      class InvalidWallet < ArgumentError; end
       class UnsupportedTokenType < ArgumentError; end
       class UnknownScriptPubkey < ArgumentError; end
       class UnsupportedDigestType < ArgumentError; end

--- a/spec/glueby/contract/timestamp/active_record/timestamp_spec.rb
+++ b/spec/glueby/contract/timestamp/active_record/timestamp_spec.rb
@@ -350,7 +350,7 @@ RSpec.describe 'Glueby::Contract::AR::Timestamp', active_record: true do
             let(:another_wallet) { Glueby::Wallet.create }
 
             it do
-              expect { subject }.to raise_error(Glueby::Contract::Errors::InvalidWallet, /The previous timestamp\(id: [0-9]+\) was created by the different user/)
+              expect { subject }.to raise_error(Glueby::Contract::Errors::FailedToBroadcast, /failed to broadcast \(id=, reason=The previous timestamp\(id: [0-9]+\) was created by the different user/)
             end
           end
         end

--- a/spec/glueby/contract/timestamp/active_record/timestamp_spec.rb
+++ b/spec/glueby/contract/timestamp/active_record/timestamp_spec.rb
@@ -332,6 +332,27 @@ RSpec.describe 'Glueby::Contract::AR::Timestamp', active_record: true do
               expect { subject }.to raise_error(Glueby::Contract::Errors::PrevTimestampIsNotTrackable, /The previous timestamp\(id: [0-9]+\) type must be trackable/)
             end
           end
+
+          context 'previous timestamp is not created by different user' do
+            before do
+              allow(Glueby::Wallet).to receive(:load).with(another_wallet.internal_wallet.id).and_return(another_wallet)
+            end
+
+            let(:prev) do
+              Glueby::Contract::AR::Timestamp.create(
+                wallet_id: another_wallet.internal_wallet.id,
+                content: "\xFF\xFF\xFF",
+                prefix: 'app',
+                timestamp_type: :trackable
+              )
+            end
+            let(:prev_id) { prev.id }
+            let(:another_wallet) { Glueby::Wallet.create }
+
+            it do
+              expect { subject }.to raise_error(Glueby::Contract::Errors::InvalidWallet, /The previous timestamp\(id: [0-9]+\) was created by the different user/)
+            end
+          end
         end
       end
     end

--- a/spec/glueby/contract/timestamp_spec.rb
+++ b/spec/glueby/contract/timestamp_spec.rb
@@ -439,8 +439,8 @@ RSpec.describe 'Glueby::Contract::Timestamp', active_record: true do
           end
         end
 
-        it 'can not sign transaction' do
-          expect { subject }.to raise_error Glueby::Internal::Wallet::Errors::InvalidSigner,  "The wallet don't have any private key of the specified payment_base"
+        it 'can not broadcast transaction' do
+          expect { subject }.to raise_error(Glueby::Contract::Errors::FailedToBroadcast, /failed to broadcast \(id=, reason=The previous timestamp\(id: [0-9]+\) was created by the different user/)
         end
       end
     end


### PR DESCRIPTION
Validate wallet_id between an updater and a creater of timestamp.