### PR TITLE
Remove dust outputs from transation in utxo provider task.

### DIFF
--- a/lib/glueby/fee_provider/tasks.rb
+++ b/lib/glueby/fee_provider/tasks.rb
@@ -38,10 +38,13 @@ module Glueby
 
         fee_outputs_count_to_be_created.times do
           txb.pay(address, fee_provider.fixed_fee)
+          sum -= fee_provider.fixed_fee
         end
+        fee = fee_provider.fixed_fee
+        fee += (sum - fee) if sum - fee < DUST_LIMIT
 
         tx = txb.change_address(address)
-                .fee(fee_provider.fixed_fee)
+                .fee(fee)
                 .build
         tx = wallet.sign_tx(tx)
         wallet.broadcast(tx, without_fee_provider: true)

--- a/lib/glueby/internal/wallet/active_record/utxo.rb
+++ b/lib/glueby/internal/wallet/active_record/utxo.rb
@@ -8,6 +8,7 @@ module Glueby
           belongs_to :key
 
           validates :txid, uniqueness: { scope: :index, case_sensitive: false }
+          validate :check_dust_output
 
           enum status: { init: 0, broadcasted: 1, finalized: 2 }
 
@@ -42,6 +43,14 @@ module Glueby
                 status: status,
                 key: key
               )
+            end
+          end
+
+        private
+
+          def check_dust_output
+            if !color_id && value < DUST_LIMIT
+              errors.add(:value, "is less than dust limit(#{DUST_LIMIT})")
             end
           end
         end

--- a/lib/glueby/utxo_provider/tasks.rb
+++ b/lib/glueby/utxo_provider/tasks.rb
@@ -46,6 +46,8 @@ module Glueby
         return if added_outputs == 0
 
         fee = fee_estimator.fee(Contract::FeeEstimator.dummy_tx(txb.build))
+        fee += (sum - fee) if sum - fee < DUST_LIMIT
+
         tx = txb.change_address(utxo_provider.address)
                 .fee(fee)
                 .build

--- a/spec/glueby/contract/timestamp/active_record/timestamp_spec.rb
+++ b/spec/glueby/contract/timestamp/active_record/timestamp_spec.rb
@@ -368,7 +368,6 @@ RSpec.describe 'Glueby::Contract::AR::Timestamp', active_record: true do
         Glueby.configuration.enable_utxo_provider!
         Glueby::UtxoProvider.instance
 
-
         # 20 Utxos are pooled.
         (0...21).each do |i|
           Glueby::Internal::Wallet::AR::Utxo.create(

--- a/spec/glueby/internal/wallet/active_record/utxo_spec.rb
+++ b/spec/glueby/internal/wallet/active_record/utxo_spec.rb
@@ -68,6 +68,30 @@ RSpec.describe 'Glueby::Internal::Wallet::AR::Utxo', active_record: true  do
 
       it { is_expected.to be_valid }
     end
+
+    context 'for tpc output' do
+      let(:utxo) do
+        Glueby::Internal::Wallet::AR::Utxo.create(
+          txid: 'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF',
+          index: 0,
+          script_pubkey: '76a91446c2fbfbecc99a63148fa076de58cf29b0bcf0b088ac',
+          value: value,
+          status: :init
+        )
+      end
+
+      context 'output value is DUST_LIMIT' do
+        let(:value) { 600 }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'output is less than the DUST_LIMIT' do
+        let(:value) { 599 }
+
+        it { is_expected.to be_invalid }
+      end
+    end
   end
 
   describe '.destroy_for_inputs' do
@@ -113,7 +137,7 @@ RSpec.describe 'Glueby::Internal::Wallet::AR::Utxo', active_record: true  do
 
     let(:tx) do
       Tapyrus::Tx.new.tap do |tx|
-        tx.outputs << Tapyrus::TxOut.new(value: 1, script_pubkey: Tapyrus::Script.parse_from_payload('76a91457dd450aed53d4e35d3555a24ae7dbf3e08a78ec88ac'.htb))
+        tx.outputs << Tapyrus::TxOut.new(value: 600, script_pubkey: Tapyrus::Script.parse_from_payload('76a91457dd450aed53d4e35d3555a24ae7dbf3e08a78ec88ac'.htb))
         tx.outputs << Tapyrus::TxOut.new(value: 1, script_pubkey: Tapyrus::Script.parse_from_payload('21c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46bc76a91457dd450aed53d4e35d3555a24ae7dbf3e08a78ec88ac'.htb))
       end
     end

--- a/spec/glueby/internal/wallet/active_record/wallet_spec.rb
+++ b/spec/glueby/internal/wallet/active_record/wallet_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Glueby::Internal::Wallet::AR::Wallet', active_record: true do
       Glueby::Internal::Wallet::AR::Utxo.create(
         txid: '0000000000000000000000000000000000000000000000000000000000000000',
         index: 0,
-        value: 1,
+        value: 600,
         script_pubkey: key1.to_p2pkh.to_hex,
         status: :init,
         key: key1
@@ -32,7 +32,7 @@ RSpec.describe 'Glueby::Internal::Wallet::AR::Wallet', active_record: true do
       Glueby::Internal::Wallet::AR::Utxo.create(
         txid: '1111111111111111111111111111111111111111111111111111111111111111',
         index: 0,
-        value: 1,
+        value: 600,
         script_pubkey: key2.to_p2pkh.to_hex,
         status: :init,
         key: key2
@@ -74,7 +74,7 @@ RSpec.describe 'Glueby::Internal::Wallet::AR::Wallet', active_record: true do
             txid: '33' * 32,
             vout: 0,
             scriptPubKey: key1.to_p2pkh.to_hex,
-            amount: 1
+            amount: 600
           }
         ]
       end
@@ -94,7 +94,7 @@ RSpec.describe 'Glueby::Internal::Wallet::AR::Wallet', active_record: true do
             txid: '33' * 32,
             vout: 0,
             scriptPubKey: key1.to_p2pkh.to_hex,
-            amount: 1
+            amount: 600
           }
         ]
       end

--- a/spec/glueby/utxo_provider/tasks_spec.rb
+++ b/spec/glueby/utxo_provider/tasks_spec.rb
@@ -145,6 +145,34 @@ RSpec.describe Glueby::UtxoProvider::Tasks, active_record: true do
             subject
           end
         end
+
+        context 'change output is dust' do
+          let(:unspents) do
+            [{
+              txid: '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5',
+              script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+              vout: 0,
+              amount: 10_000,
+              finalized: true
+            }, {
+              txid: '5c3d79041ff4974282b8ab72517d2ef15d8b6273cb80a01077145afb3d5e7cc5',
+              script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+              vout: 1,
+              amount: 20_500,
+              finalized: true
+            }]
+          end
+          let(:balance) { 30_500 }
+
+          it 'removes change output from transaction' do
+            # amount of change output is 30,500 - 20 * 1,000 - 10,000 = 500(tapyrus), which is `dust` output
+            expect(wallet).to receive(:broadcast) do |tx|
+              expect(tx.outputs.count).to eq(20) # default UTXO pool size
+              expect(tx.outputs[0...20].map(&:value).uniq).to eq([1_000]) # a change output is removed
+            end
+            subject
+          end
+        end
       end
 
       context 'The wallet has no TPC' do


### PR DESCRIPTION
For now, `Glueby::UtxoProvider::Tasks::manage_utxo_pool` and `Glueby::FeeProvider::Tasks::manage_utxo_pool` create dust output in the case that amount value of change output is less than DUST_LIMIT value.
In this case, tx built with "mange_utxo_pool" method would be rejected to full node
This PR fixes the problem by removing dust output.

