### PR TITLE
Add rake task to skip synchronization process

### DIFF
--- a/lib/tasks/glueby/block_syncer.rake
+++ b/lib/tasks/glueby/block_syncer.rake
@@ -25,5 +25,12 @@ namespace :glueby do
         puts "success in synchronization (block height=#{height})"
       end
     end
+
+    desc 'Update the block height in Glueby::AR::SystemInformation and do not run Glueby::BlockSyncer. This task is intended to skip the synchronization process until the latest block height.'
+    task :update_height, [] => [:environment] do |_, _|
+      new_height = Glueby::Internal::RPC.client.getblockcount
+      synced_block = Glueby::AR::SystemInformation.synced_block_height
+      synced_block.update(info_value: new_height.to_s)
+    end
   end
 end

--- a/spec/tasks/glueby/block_syncer_spec.rb
+++ b/spec/tasks/glueby/block_syncer_spec.rb
@@ -25,6 +25,22 @@ RSpec.describe 'glueby:block_syncer', active_record: true do
       expect(Glueby::Internal::Wallet::AR::Utxo.count).to eq(2)
     end
   end
+
+  describe '#update_height' do
+    subject { Rake.application['glueby:block_syncer:update_height'] }
+
+    it do
+      expect(rpc).to receive(:getblockcount).once
+      expect(rpc).to receive(:getblock).exactly(0).times
+      expect(rpc).to receive(:getblockhash).exactly(0).times
+      expect(rpc).to receive(:getrawtransaction).exactly(0).times
+      expect(Glueby::AR::SystemInformation.synced_block_height.int_value).to eq(0)
+      expect(Glueby::Internal::Wallet::AR::Utxo.count).to eq(1)
+      subject.invoke
+      expect(Glueby::AR::SystemInformation.synced_block_height.int_value).to eq(2)
+      expect(Glueby::Internal::Wallet::AR::Utxo.count).to eq(1)
+    end
+  end
 end
 
 RSpec.describe 'glueby:contract:block_syncer', active_record: true do


### PR DESCRIPTION
In some applications, the initial synchronization process is very time-consuming. To improve this, this PR adds a rake task that skips the synchronization process of the blocks when the application is introduced.