### PR TITLE
Lock utxo with SKIP LOCKED option

### DIFF
--- a/glueby.gemspec
+++ b/glueby.gemspec
@@ -29,5 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'tapyrus', '>= 0.3.1'
   spec.add_runtime_dependency 'activerecord', '~> 6.1.3'
   spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'mysql2'
   spec.add_development_dependency 'rails', '~> 6.1.3'
 end

--- a/lib/generators/glueby/contract/templates/utxo_table.rb.erb
+++ b/lib/generators/glueby/contract/templates/utxo_table.rb.erb
@@ -7,6 +7,7 @@ class CreateUtxo < ActiveRecord::Migration<%= migration_version %>
       t.string     :script_pubkey
       t.string     :label, index: true
       t.integer    :status
+      t.datetime   :locked_at
       t.belongs_to :key, null: true
       t.timestamps
     end

--- a/lib/glueby/configuration.rb
+++ b/lib/glueby/configuration.rb
@@ -31,6 +31,8 @@ module Glueby
         Glueby::Internal::Wallet.wallet_adapter = Glueby::Internal::Wallet::TapyrusCoreWalletAdapter.new
       when :activerecord
         Glueby::Internal::Wallet.wallet_adapter = Glueby::Internal::Wallet::ActiveRecordWalletAdapter.new
+      when :mysql
+        Glueby::Internal::Wallet.wallet_adapter = Glueby::Internal::Wallet::MySQLWalletAdapter.new
       else
         raise 'Not implemented'
       end

--- a/lib/glueby/internal/wallet.rb
+++ b/lib/glueby/internal/wallet.rb
@@ -93,6 +93,10 @@ module Glueby
         wallet_adapter.list_unspent(id, only_finalized, label)
       end
 
+      def lock_unspent(utxo)
+        wallet_adapter.lock_unspent(id, utxo)
+      end
+
       def delete
         wallet_adapter.delete_wallet(id)
       end

--- a/lib/glueby/internal/wallet.rb
+++ b/lib/glueby/internal/wallet.rb
@@ -31,6 +31,7 @@ module Glueby
       autoload :AR, 'glueby/internal/wallet/active_record'
       autoload :TapyrusCoreWalletAdapter, 'glueby/internal/wallet/tapyrus_core_wallet_adapter'
       autoload :ActiveRecordWalletAdapter, 'glueby/internal/wallet/active_record_wallet_adapter'
+      autoload :MySQLWalletAdapter, 'glueby/internal/wallet/mysql_wallet_adapter'
       autoload :Errors, 'glueby/internal/wallet/errors'
 
       include GluebyLogger

--- a/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
@@ -91,7 +91,7 @@ module Glueby
         # @param wallet_id [String] The wallet id that is offered by `create_wallet()` method.
         # @param utxo [Hash] The utxo hash object
         def lock_unspent(wallet_id, utxo)
-          raise NotImplementedError, "You must implement #{self.class}##{__method__}"
+          true
         end
 
         # Sign to the transaction with a key in the wallet.

--- a/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
@@ -86,6 +86,14 @@ module Glueby
           raise NotImplementedError, "You must implement #{self.class}##{__method__}"
         end
 
+        # Attempt to lock a specified utxo and update status to 'spending'
+        #
+        # @param wallet_id [String] The wallet id that is offered by `create_wallet()` method.
+        # @param utxo [Hash] The utxo hash object
+        def lock_unspent(wallet_id, utxo)
+          raise NotImplementedError, "You must implement #{self.class}##{__method__}"
+        end
+
         # Sign to the transaction with a key in the wallet.
         #
         # @param [String] wallet_id - The wallet id that is offered by `create_wallet()` method.

--- a/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
@@ -86,7 +86,7 @@ module Glueby
           raise NotImplementedError, "You must implement #{self.class}##{__method__}"
         end
 
-        # Attempt to lock a specified utxo and update status to 'spending'
+        # Attempt to lock a specified utxo and update lock_at field
         #
         # @param wallet_id [String] The wallet id that is offered by `create_wallet()` method.
         # @param utxo [Hash] The utxo hash object

--- a/lib/glueby/internal/wallet/active_record/utxo.rb
+++ b/lib/glueby/internal/wallet/active_record/utxo.rb
@@ -9,7 +9,7 @@ module Glueby
 
           validates :txid, uniqueness: { scope: :index, case_sensitive: false }
 
-          enum status: { init: 0, broadcasted: 1, finalized: 2, spending: 3 }
+          enum status: { init: 0, broadcasted: 1, finalized: 2 }
 
           def color_id
             script = Tapyrus::Script.parse_from_payload(script_pubkey.htb)

--- a/lib/glueby/internal/wallet/active_record/utxo.rb
+++ b/lib/glueby/internal/wallet/active_record/utxo.rb
@@ -9,7 +9,7 @@ module Glueby
 
           validates :txid, uniqueness: { scope: :index, case_sensitive: false }
 
-          enum status: { init: 0, broadcasted: 1, finalized: 2 }
+          enum status: { init: 0, broadcasted: 1, finalized: 2, spending: 3 }
 
           def color_id
             script = Tapyrus::Script.parse_from_payload(script_pubkey.htb)

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -116,11 +116,7 @@ module Glueby
         end
 
         def lock_unspent(wallet_id, utxo)
-          ActiveRecord::Base.transaction(joinable: false, requires_new: true) do
-            record = AR::Utxo.lock("FOR UPDATE SKIP LOCKED").find_by(txid: utxo[:txid], index: utxo[:vout])
-            record&.update!(status: :spending)
-            record
-          end
+          true
         end
 
         def sign_tx(wallet_id, tx, prevtxs = [], sighashtype: Tapyrus::SIGHASH_TYPE[:all])

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -84,23 +84,15 @@ module Glueby
 
         def balance(wallet_id, only_finalized = true)
           wallet = AR::Wallet.find_by(wallet_id: wallet_id)
-          utxos = wallet.utxos
-          utxos = if only_finalized
-            utxos.where(status: :finalized)
-          else
-            utxos.where(status: [:finalized, :broadcasted])
-          end
+          utxos = wallet.utxos.where(locked_at: nil)
+          utxos = utxos.where(status: :finalized) if only_finalized
           utxos.sum(&:value)
         end
 
         def list_unspent(wallet_id, only_finalized = true, label = nil)
           wallet = AR::Wallet.find_by(wallet_id: wallet_id)
-          utxos = wallet.utxos
-          utxos = if only_finalized
-            utxos.where(status: :finalized)
-          else
-            utxos.where(status: [:finalized, :broadcasted])
-          end
+          utxos = wallet.utxos.where(locked_at: nil)
+          utxos = utxos.where(status: :finalized) if only_finalized
           if [:unlabeled, nil].include?(label)
             utxos = utxos.where(label: nil)
           elsif label && (label != :all)

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -115,6 +115,14 @@ module Glueby
           end
         end
 
+        def lock_unspent(wallet_id, utxo)
+          ActiveRecord::Base.transaction(joinable: false, requires_new: true) do
+            record = AR::Utxo.lock("FOR UPDATE SKIP LOCKED").find_by(txid: utxo[:txid], index: utxo[:vout])
+            record&.update!(status: :spending)
+            record
+          end
+        end
+
         def sign_tx(wallet_id, tx, prevtxs = [], sighashtype: Tapyrus::SIGHASH_TYPE[:all])
           wallet = AR::Wallet.find_by(wallet_id: wallet_id)
           wallet.sign(tx, prevtxs, sighashtype: sighashtype)

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -115,10 +115,6 @@ module Glueby
           end
         end
 
-        def lock_unspent(wallet_id, utxo)
-          true
-        end
-
         def sign_tx(wallet_id, tx, prevtxs = [], sighashtype: Tapyrus::SIGHASH_TYPE[:all])
           wallet = AR::Wallet.find_by(wallet_id: wallet_id)
           wallet.sign(tx, prevtxs, sighashtype: sighashtype)

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -85,15 +85,22 @@ module Glueby
         def balance(wallet_id, only_finalized = true)
           wallet = AR::Wallet.find_by(wallet_id: wallet_id)
           utxos = wallet.utxos
-          utxos = utxos.where(status: :finalized) if only_finalized
+          utxos = if only_finalized
+            utxos.where(status: :finalized)
+          else
+            utxos.where(status: [:finalized, :broadcasted])
+          end
           utxos.sum(&:value)
         end
 
         def list_unspent(wallet_id, only_finalized = true, label = nil)
           wallet = AR::Wallet.find_by(wallet_id: wallet_id)
           utxos = wallet.utxos
-          utxos = utxos.where(status: :finalized) if only_finalized
-
+          utxos = if only_finalized
+            utxos.where(status: :finalized)
+          else
+            utxos.where(status: [:finalized, :broadcasted])
+          end
           if [:unlabeled, nil].include?(label)
             utxos = utxos.where(label: nil)
           elsif label && (label != :all)

--- a/lib/glueby/internal/wallet/mysql_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/mysql_wallet_adapter.rb
@@ -6,8 +6,8 @@ module Glueby
       class MySQLWalletAdapter < ActiveRecordWalletAdapter
         def lock_unspent(wallet_id, utxo)
           ActiveRecord::Base.transaction(joinable: false, requires_new: true) do
-            record = AR::Utxo.lock("FOR UPDATE SKIP LOCKED").find_by(txid: utxo[:txid], index: utxo[:vout], status: [:init, :finalized, :broadcasted])
-            record&.update!(status: :spending)
+            record = AR::Utxo.lock("FOR UPDATE SKIP LOCKED").find_by(txid: utxo[:txid], index: utxo[:vout], locked_at: nil)
+            record&.update!(locked_at: Time.now)
             record
           end
         end

--- a/lib/glueby/internal/wallet/mysql_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/mysql_wallet_adapter.rb
@@ -6,7 +6,7 @@ module Glueby
       class MySQLWalletAdapter < ActiveRecordWalletAdapter
         def lock_unspent(wallet_id, utxo)
           ActiveRecord::Base.transaction(joinable: false, requires_new: true) do
-            record = AR::Utxo.lock("FOR UPDATE SKIP LOCKED").find_by(txid: utxo[:txid], index: utxo[:vout], status: :finalized)
+            record = AR::Utxo.lock("FOR UPDATE SKIP LOCKED").find_by(txid: utxo[:txid], index: utxo[:vout], status: [:init, :finalized, :broadcasted])
             record&.update!(status: :spending)
             record
           end

--- a/lib/glueby/internal/wallet/mysql_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/mysql_wallet_adapter.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Glueby
+  module Internal
+    class Wallet
+      class MySQLWalletAdapter < ActiveRecordWalletAdapter
+        def lock_unspent(wallet_id, utxo)
+          ActiveRecord::Base.transaction(joinable: false, requires_new: true) do
+            record = AR::Utxo.lock("FOR UPDATE SKIP LOCKED").find_by(txid: utxo[:txid], index: utxo[:vout], status: :finalized)
+            record&.update!(status: :spending)
+            record
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/glueby/utxo_provider.rb
+++ b/lib/glueby/utxo_provider.rb
@@ -159,12 +159,13 @@ module Glueby
           !excludes.find { |i| i[:txid] == o[:txid] && i[:vout] == o[:vout] }
       end
       utxos.shuffle!
-
+      
       utxos.inject([0, []]) do |(sum, outputs), output|
-        sum += output[:amount]
-        outputs << output
-        return [sum, outputs] if sum >= amount
-
+        if wallet.lock_unspent(output)
+          sum += output[:amount]
+          outputs << output
+          return [sum, outputs] if sum >= amount
+        end
         [sum, outputs]
       end
       raise Glueby::Contract::Errors::InsufficientFunds

--- a/spec/functional/token_spec.rb
+++ b/spec/functional/token_spec.rb
@@ -433,7 +433,7 @@ RSpec.describe 'Token Contract', functional: true do
       threads.map { |t| t.value }
     end
 
-    it do
+    it 'broadast transactions with no error on multi thread' do
       expect(Glueby::UtxoProvider.instance.current_utxo_pool_size).to eq utxo_pool_size
       tokens = issue_on_multi_thread(count)
       process_block

--- a/spec/functional/token_spec.rb
+++ b/spec/functional/token_spec.rb
@@ -408,4 +408,42 @@ RSpec.describe 'Token Contract', functional: true do
       end
     end
   end
+
+  context 'use mysql', mysql: true do
+    include_context 'setup utxo provider'
+    let(:utxo_pool_size) { 40 }
+
+    let(:sender) { Glueby::Wallet.create }
+    let(:receiver) { Glueby::Wallet.create }
+    let(:before_balance) { sender.balances(false)[''] }
+    let(:count) { 20 }
+
+    def issue_on_multi_thread(count)
+      threads = count.times.map do |i|
+        Thread.new do
+          token, _txs = Glueby::Contract::Token.issue!(
+            issuer: sender,
+            token_type: Tapyrus::Color::TokenTypes::REISSUABLE,
+            amount: 10_000
+          )
+          token
+        end
+      end
+      # Each value is Token object
+      threads.map { |t| t.value }
+    end
+
+    it do
+      expect(Glueby::UtxoProvider.instance.current_utxo_pool_size).to eq utxo_pool_size
+      tokens = issue_on_multi_thread(count)
+      process_block
+
+      expect(sender.balances(false)['']).to eq(before_balance)
+      tokens.each do |token|
+        expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
+      end
+
+      expect(Glueby::UtxoProvider.instance.current_utxo_pool_size).to eq utxo_pool_size - count
+    end
+  end
 end

--- a/spec/glueby/contract/tx_builder_spec.rb
+++ b/spec/glueby/contract/tx_builder_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'Glueby::Contract::TxBuilder' do
       Glueby.configuration.enable_utxo_provider!
       Glueby::Internal::Wallet.wallet_adapter = wallet_adapter
       allow(wallet_adapter).to receive(:load_wallet)
+      allow(wallet_adapter).to receive(:lock_unspent).and_return(true)
       allow_any_instance_of(Glueby::UtxoProvider).to receive(:wallet).and_return(utxo_provider_wallet)
       allow(utxo_provider_wallet).to receive(:list_unspent).and_return(pool_outputs)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,13 +29,13 @@ RSpec.configure do |config|
       Glueby.configuration.rpc_config = { schema: 'http', host: '127.0.0.1', port: 12382, user: 'user', password: 'pass' }
       TapyrusCoreContainer.setup
       TapyrusCoreContainer.start
-    end
 
-    if example.metadata[:mysql]
-      Glueby.configuration.wallet_adapter = :mysql
-      MySQLContainer.setup
-      MySQLContainer.start
-      setup_database(config: MySQLContainer.config)
+      if example.metadata[:mysql]
+        Glueby.configuration.wallet_adapter = :mysql
+        MySQLContainer.setup
+        MySQLContainer.start
+        setup_database(config: MySQLContainer.config)
+      end
     end
   end
 
@@ -47,11 +47,11 @@ RSpec.configure do |config|
     if example.metadata[:functional]
       Tapyrus.chain_params = :prod
       TapyrusCoreContainer.teardown
-    end
 
-    if example.metadata[:mysql]
-      Glueby::Internal::Wallet.wallet_adapter = nil
-      MySQLContainer.teardown
+      if example.metadata[:mysql]
+        Glueby::Internal::Wallet.wallet_adapter = nil
+        MySQLContainer.teardown
+      end
     end
 
     # Reset Glueby::UtxoProvider singleton instance
@@ -241,6 +241,10 @@ class TestInternalWallet < Glueby::Internal::Wallet
 
   def list_unspent(only_finalized = true, label = nil)
     []
+  end
+
+  def lock_unspent(utxo)
+    true
   end
 
   def change_address

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,13 @@ RSpec.configure do |config|
       TapyrusCoreContainer.setup
       TapyrusCoreContainer.start
     end
+
+    if example.metadata[:mysql]
+      Glueby.configuration.wallet_adapter = :mysql
+      MySQLContainer.setup
+      MySQLContainer.start
+      setup_database(config: MySQLContainer.config)
+    end
   end
 
   config.after(:each) do |example|
@@ -40,6 +47,11 @@ RSpec.configure do |config|
     if example.metadata[:functional]
       Tapyrus.chain_params = :prod
       TapyrusCoreContainer.teardown
+    end
+
+    if example.metadata[:mysql]
+      Glueby::Internal::Wallet.wallet_adapter = nil
+      MySQLContainer.teardown
     end
 
     # Reset Glueby::UtxoProvider singleton instance
@@ -58,11 +70,16 @@ RSpec.configure do |config|
   end
 end
 
+require_relative 'support/mysql'
 require_relative 'support/setup_fee_provider'
 require_relative 'support/setup_utxo_provider'
 
-def setup_database
-  config = { adapter: 'sqlite3', database: File.join(Dir.tmpdir, 'glueby-test-db') }
+def sqlite3_config
+  { adapter: 'sqlite3', database: File.join(Dir.tmpdir, 'glueby-test-db') }
+end
+
+def setup_database(config: sqlite3_config)
+  
   ::ActiveRecord::Base.establish_connection(config)
   connection = ::ActiveRecord::Base.connection
   connection.create_table :glueby_wallets do |t|
@@ -158,7 +175,12 @@ class TapyrusCoreContainer
   attr_reader :container
 
   def setup
-    Docker::Image.get("tapyrus/tapyrusd:#{TAPYRUSD_VERSION}")
+    begin
+      Docker::Image.get("tapyrus/tapyrusd:#{TAPYRUSD_VERSION}")
+    rescue Docker::Error::NotFoundError => e
+      Docker::Image.create(fromImage: "tapyrus/tapyrusd:#{TAPYRUSD_VERSION}")
+    end
+
     @container = Docker::Container.create({
       name: TAPYRUSD_CONTAINER_NAME,
       "Image"=>"tapyrus/tapyrusd:#{TAPYRUSD_VERSION}",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,6 +107,7 @@ def setup_database(config: sqlite3_config)
     t.string     :script_pubkey
     t.string     :label, index: true
     t.integer    :status
+    t.datetime   :locked_at
     t.belongs_to :key, null: true
     t.timestamps
   end

--- a/spec/support/mysql.rb
+++ b/spec/support/mysql.rb
@@ -1,0 +1,81 @@
+
+
+# Class for Docker container to run MySQL specific test cases
+class MySQLContainer
+  include Singleton
+
+  MYSQL_VERSION = "8.0"
+  MYSQL_CONTAINER_NAME = "db"
+
+  class << self
+    extend Forwardable
+    delegate %i[setup start stop teardown config] => :instance
+  end
+
+  attr_reader :container
+
+  def config
+    @config ||= {
+      adapter: 'mysql2',
+      database: 'glueby_test',
+      encoding: 'utf8mb4',
+      pool: 40,
+      username: 'root',
+      password: 'password',
+      host: '127.0.0.1'
+    }
+  end
+
+  def setup
+    begin
+      Docker::Image.get("mysql:#{MYSQL_VERSION}")
+    rescue Docker::Error::NotFoundError => e
+      Docker::Image.create(fromImage: "mysql:#{MYSQL_VERSION}")
+    end
+
+    @container = Docker::Container.create({
+      name: MYSQL_CONTAINER_NAME,
+      "Image" => "mysql:#{MYSQL_VERSION}",
+      "Env" => [
+        "MYSQL_ROOT_PASSWORD=password"
+      ],
+      "HostConfig" => {
+        "PortBindings" => { "3306/tcp" => [{ "HostIp" => "", "HostPort" => "3306" }] },
+      }
+    })
+  end
+
+  def start
+    container.start!
+
+    wait_for_connecting
+  end
+
+  def wait_for_connecting
+    sleep(1)
+    ::ActiveRecord::Base.establish_connection(config)
+    connection = ::ActiveRecord::Base.connection
+  rescue ActiveRecord::NoDatabaseError => e
+    client = Mysql2::Client.new(
+      :host => config[:host],
+      :username => config[:username],
+      :password => config[:password]
+    )
+    client.query("CREATE DATABASE #{config[:database]}")
+    client.query("USE #{config[:database]}")
+    retry
+  rescue => e
+    puts e
+    retry
+  end
+
+  def stop
+    container.stop!
+  end
+
+  def teardown
+    container = Docker::Container.get(MYSQL_CONTAINER_NAME)
+    container.stop!
+    container.remove
+  end
+end

--- a/spec/support/setup_utxo_provider.rb
+++ b/spec/support/setup_utxo_provider.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.shared_context 'setup utxo provider' do
+  let(:default_fixed_fee) { 2_000 }
+  let(:default_value) { 4_000 }
+  let(:utxo_pool_size) { 20 }
+
   before do
-    Glueby::Contract::FeeEstimator::Fixed.default_fixed_fee = 2000
+    Glueby::Contract::FeeEstimator::Fixed.default_fixed_fee = default_fixed_fee
     Glueby.configure do |config|
       config.enable_utxo_provider!
       config.utxo_provider_config = {
-        default_value: 4_000,
-        utxo_pool_size: 20
+        default_value: default_value,
+        utxo_pool_size: utxo_pool_size
       }
     end
     # create UTXOs in the UTXO pool


### PR DESCRIPTION
This works in the case the application uses MySQL (or Postgresql).

UtxoProviderが重複してUtxoを選択しないように `UtxoProvider#collect_uncolored_outputs` でのUtxoの収集時にロックされたUtxoは検索スキップするようにしました。
使用する場合は、wallet adapter にMySQLWalletAdapterを選択するようにしてください。

```
Glueby.configuration.wallet_adapter = :mysql
```

