### PR TITLE
Use parameter key_type instead 'compressed' parameter

### DIFF
--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -399,7 +399,7 @@ module Glueby
       def valid_reissuer?(wallet:, token_metadata: nil)
         return false unless script_pubkey&.p2pkh?
         address = if token_metadata
-            payment_base = Tapyrus::Key.new(pubkey: token_metadata.payment_base)
+            payment_base = Tapyrus::Key.new(pubkey: token_metadata.payment_base, key_type: Tapyrus::Key::TYPES[:compressed])
             payment_base.to_p2pkh
           else
             script_pubkey.to_addr

--- a/lib/glueby/internal/wallet/active_record/key.rb
+++ b/lib/glueby/internal/wallet/active_record/key.rb
@@ -20,7 +20,7 @@ module Glueby
           end
 
           def sign(data)
-            Tapyrus::Key.new(priv_key: self.private_key).sign(data, algo: :schnorr)
+            Tapyrus::Key.new(priv_key: self.private_key, key_type: Tapyrus::Key::TYPES[:compressed]).sign(data, algo: :schnorr)
           end
 
           def address
@@ -54,7 +54,7 @@ module Glueby
 
           def generate_key
             key = if private_key
-              Tapyrus::Key.new(priv_key: private_key)
+              Tapyrus::Key.new(priv_key: private_key, key_type: Tapyrus::Key::TYPES[:compressed])
             else
               Tapyrus::Key.generate
             end

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -144,7 +144,7 @@ module Glueby
         def create_pubkey(wallet_id)
           wallet = AR::Wallet.find_by(wallet_id: wallet_id)
           key = wallet.keys.create(purpose: :receive)
-          Tapyrus::Key.new(pubkey: key.public_key)
+          Tapyrus::Key.new(pubkey: key.public_key, key_type: Tapyrus::Key::TYPES[:compressed])
         end
 
         def get_addresses(wallet_id, label = nil)
@@ -165,7 +165,7 @@ module Glueby
           p = pubkey.to_point # P
           commitment = create_pay_to_contract_commitment(pubkey, contents)
           point = p + group.generator.multiply_by_scalar(commitment) # P + H(P || contents)G
-          Tapyrus::Key.new(pubkey: point.to_hex(true))
+          Tapyrus::Key.new(pubkey: point.to_hex(true), key_type: Tapyrus::Key::TYPES[:compressed])
         end
 
         def sign_to_pay_to_contract_address(wallet_id, tx, utxo, payment_base, contents)
@@ -208,9 +208,9 @@ module Glueby
           ar_key = wallet.keys.where(public_key: payment_base).first
           raise Errors::InvalidSigner, "The wallet don't have any private key of the specified payment_base" unless ar_key
 
-          key = Tapyrus::Key.new(pubkey: payment_base)
+          key = Tapyrus::Key.new(pubkey: payment_base, key_type: Tapyrus::Key::TYPES[:compressed])
           commitment = create_pay_to_contract_commitment(key, contents)
-          Tapyrus::Key.new(priv_key: ((ar_key.private_key.to_i(16) + commitment) % group.order).to_even_length_hex) # K + commitment
+          Tapyrus::Key.new(priv_key: ((ar_key.private_key.to_i(16) + commitment) % group.order).to_even_length_hex, key_type: Tapyrus::Key::TYPES[:compressed]) # K + commitment
         end
       end
     end

--- a/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/tapyrus_core_wallet_adapter.rb
@@ -149,7 +149,7 @@ module Glueby
           perform_as(wallet_id) do |client|
             address = client.getnewaddress('')
             info = client.getaddressinfo(address)
-            Tapyrus::Key.new(pubkey: info['pubkey'])
+            Tapyrus::Key.new(pubkey: info['pubkey'], key_type: Tapyrus::Key::TYPES[:compressed])
           end
         end
 

--- a/spec/glueby/internal/wallet/active_record/key_spec.rb
+++ b/spec/glueby/internal/wallet/active_record/key_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'Glueby::Internal::Wallet::AR::Key', active_record: true  do
     let(:data) { '61b04781dec482815d8fc22d6074a57e184973e96870e2f59dab0a5851b1b4dd'.htb }
 
     it { expect(subject).to eq '20661fb45b90f336c150ef7ee1dbcf6872e6e1af34a5d71878d4590e42722500d5ba107944d679a3b9ac30de6f2cbc586498e5a09fdfdeb9c3a3af9971212cda' }
-    it { expect(Tapyrus::Key.new(priv_key: private_key).verify(subject.htb, data, algo: :schnorr)).to be_truthy }
+    it { expect(Tapyrus::Key.new(priv_key: private_key, key_type: Tapyrus::Key::TYPES[:compressed]).verify(subject.htb, data, algo: :schnorr)).to be_truthy }
   end
 
   describe '.key_for_output' do


### PR DESCRIPTION
When the taypurs key is created with `Tapyrus::Key.new()`, a warning message is  printed:

```  
Use key_type parameter instead of compressed. compressed parameter removed in the future.
```
This PR fixes the way to create a Key like this:

```
Tapyrus::Key.new(priv_key: key) => Tapyrus::Key.new(priv_key: key, key_type: Tapyrus::Key::TYPES[:compressed])
```

In most cases in glueby, we use `compressed` key only.
