### PR TITLE
Timestamp created by different signer should raise record invalid

### DIFF
--- a/lib/glueby/contract/active_record/timestamp.rb
+++ b/lib/glueby/contract/active_record/timestamp.rb
@@ -176,7 +176,7 @@ module Glueby
         def validate_prev
           validate_prev!
           true
-        rescue Errors::ArgumentError
+        rescue Errors::ArgumentError, Glueby::Internal::Wallet::Errors::InvalidSigner
           false
         end
 

--- a/spec/glueby/contract/timestamp/active_record/timestamp_spec.rb
+++ b/spec/glueby/contract/timestamp/active_record/timestamp_spec.rb
@@ -129,6 +129,22 @@ RSpec.describe 'Glueby::Contract::AR::Timestamp', active_record: true do
         end
       end
 
+      context 'the prev timestamp is created by the different user' do
+        let!(:prev) do
+          Glueby::Contract::AR::Timestamp.create!({
+            wallet_id: '11111111111111111111111111111111',
+            content: "\xFF\xFF\xFF",
+            prefix: 'app',
+            timestamp_type: 'trackable'
+          })
+        end
+
+        it 'error' do
+          expect { Glueby::Contract::AR::Timestamp.create!(valid_attributes.merge(prev_id: prev.id)) }
+            .to raise_error(ActiveRecord::RecordInvalid, /Validation failed: Prev The previous timestamp\(id: [0-9]+\) was created by the different user/)
+        end
+      end
+
       context 'prev is simple timestamp' do
         let!(:prev) do
           Glueby::Contract::AR::Timestamp.create!(valid_attributes.merge(timestamp_type: :simple))


### PR DESCRIPTION
trackable型のタイムスタンプを更新する際にwalletのIDが変わっていた場合にInvalidSignerをraiseしている(https://github.com/chaintope/glueby/pull/153) が、
InvalidSignerがArgumentErrorではないため、validation時にfalseを返さずraiseしていた。
