### PR TITLE
Add get_addresses_info to the internal wallet

### DIFF
--- a/lib/glueby/internal/wallet.rb
+++ b/lib/glueby/internal/wallet.rb
@@ -73,6 +73,10 @@ module Glueby
           @wallet_adapter or
             raise Errors::ShouldInitializeWalletAdapter, 'You should initialize wallet adapter using `Glueby::Internal::Wallet.wallet_adapter = some wallet adapter instance`.'
         end
+
+        def get_addresses_info(addresses)
+          @wallet_adapter.get_addresses_info(addresses)
+        end
       end
 
       attr_reader :id

--- a/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/abstract_wallet_adapter.rb
@@ -135,6 +135,15 @@ module Glueby
           raise NotImplementedError, "You must implement #{self.class}##{__method__}"
         end
 
+        # Returns information for the addresses
+        #
+        # @param [String] address - The p2pkh address to get information about
+        # @return [Array<Hash>] The array of hash instance which has keys wallet_id, label and purpose.
+        #                       Returns blank array if the key correspond with the address is not exist.
+        def get_addresses_info(addresses)
+          raise NotImplementedError, "You must implement #{self.class}##{__method__}"
+        end
+
         # Returns a new public key.
         #
         # This method is expected to returns a new public key. The key would generate internally. This key is provided

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -153,6 +153,30 @@ module Glueby
           keys.map(&:address)
         end
 
+        def get_addresses_info(addresses)
+          unless addresses.is_a?(Array)
+            addresses = [addresses]
+          end
+
+          script_pubkeys = addresses.map do |address|
+            Tapyrus::Script.parse_from_addr(address).to_hex
+          rescue ::ArgumentError => e
+            raise Glueby::ArgumentError, "\"#{address}\" is invalid address. #{e.message}"
+          end
+
+          keys = AR::Key.where(script_pubkey: script_pubkeys)
+          keys.map do |key|
+            {
+              address: key.address,
+              public_key: key.public_key,
+              wallet_id: key.wallet.wallet_id,
+              label: key.label,
+              purpose: key.purpose,
+              script_pubkey: key.script_pubkey
+            }
+          end
+        end
+
         def create_pay_to_contract_address(wallet_id, contents)
           pubkey = create_pubkey(wallet_id)
           [pay_to_contract_key(wallet_id, pubkey, contents).to_p2pkh, pubkey.pubkey]

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -162,6 +162,12 @@ module Glueby
             Tapyrus::Script.parse_from_addr(address).to_hex
           rescue ::ArgumentError => e
             raise Glueby::ArgumentError, "\"#{address}\" is invalid address. #{e.message}"
+          rescue RuntimeError => e
+            if e.message == 'Invalid version bytes.' || e.message == 'Invalid address.'
+              raise Glueby::ArgumentError, "\"#{address}\" is invalid address. #{e.message}"
+            else
+              raise e
+            end
           end
 
           keys = AR::Key.where(script_pubkey: script_pubkeys)

--- a/spec/glueby/internal/wallet/active_record_wallet_adapter_spec.rb
+++ b/spec/glueby/internal/wallet/active_record_wallet_adapter_spec.rb
@@ -322,6 +322,88 @@ RSpec.describe 'Glueby::Internal::Wallet::ActiveRecordWalletAdapter', active_rec
     end
   end
 
+  describe '#get_addresses_info' do
+    subject { adapter.get_addresses_info(addresses) }
+
+    before do
+      # Skip callbacks
+      allow(Glueby::Internal::Wallet::AR::Key).to receive(:generate_key)
+      allow(Glueby::Internal::Wallet::AR::Key).to receive(:set_script_pubkey)
+    end
+
+    let!(:keys) do
+      [
+        Glueby::Internal::Wallet::AR::Key.create!({
+          private_key: 'b850e10e8265973f5cd65b385beb1452132dbe10b7eb2a0107c5a04cb2010896',
+          public_key: '0221cc1113cb761d650b27e0e8d4a36802427a53bdd3ed631bd6ffc2fd6b5927b3',
+          script_pubkey: '76a9142f2776cc7fa11adc44a5568604f95283e964a43988ac',
+          label: label,
+          purpose: purpose,
+          wallet_id: wallet.id
+        }),
+        Glueby::Internal::Wallet::AR::Key.create!({
+          private_key: '34d477342334e70ea4259a944e14a3fdd8ce2657c874bcc3a5b94c1a3f754747',
+          public_key: '023b5c432e5d3174900b8c845e8311c1d7fffdd482a60b8c966b13497694bbdb2e',
+          script_pubkey: '76a914a23178289ed6e2a15bd760e7406f85b32d79c17888ac',
+          label: label,
+          purpose: purpose,
+          wallet_id: wallet.id
+        })
+      ]
+    end
+    let(:addresses) { ['15JL32ZJTEeNUT7Fs348errZ8xmavXXhLp', '1FnbjGaaHaitz9FwTpDq4Ss8AkeKpLB5YY'] }
+    let(:purpose) { 'receive' }
+    let(:label) { nil }
+    let(:valid_result) do
+      [
+        {
+          address: '15JL32ZJTEeNUT7Fs348errZ8xmavXXhLp',
+          public_key: '0221cc1113cb761d650b27e0e8d4a36802427a53bdd3ed631bd6ffc2fd6b5927b3',
+          wallet_id: wallet.wallet_id,
+          label: label,
+          script_pubkey: '76a9142f2776cc7fa11adc44a5568604f95283e964a43988ac',
+          purpose: purpose
+        },
+        {
+          address: '1FnbjGaaHaitz9FwTpDq4Ss8AkeKpLB5YY',
+          public_key: '023b5c432e5d3174900b8c845e8311c1d7fffdd482a60b8c966b13497694bbdb2e',
+          wallet_id: wallet.wallet_id,
+          label: label,
+          script_pubkey: '76a914a23178289ed6e2a15bd760e7406f85b32d79c17888ac',
+          purpose: purpose
+        }
+      ]
+    end
+
+    context 'valid address' do
+      context 'receive_address' do
+        it { expect(subject).to eq(valid_result) }
+      end
+
+      context 'change_address' do
+        let(:purpose) { 'change' }
+
+        it { expect(subject).to eq(valid_result) }
+      end
+
+      context 'labeld address' do
+        let(:label) { 'Glueby-Contract-Tracking' }
+
+        it { expect(subject).to eq(valid_result) }
+      end
+    end
+
+    context 'invalid address' do
+      let(:addresses) { ['15JL32ZJTEeNUT7Fs348errZ8xmavXXhLp', '1FnbjGaaHaitz9FwTpDq4Ss8AkeKpLB5YY', 'invalidaddress1FnbjGaaHaitz9FwTpDq4Ss8AkeKpLB5YY'] }
+      it { expect { subject }.to raise_error(Glueby::ArgumentError, '"invalidaddress1FnbjGaaHaitz9FwTpDq4Ss8AkeKpLB5YY" is invalid address. Value passed not a valid Base58 String.') }
+    end
+
+    context 'the addresses are not managed in the wallet' do
+      let(:addresses) { ["1Dc9f6MvAKB4L3xhzD61YMgd12JdsGUg6N", "17i5rxVcXsujjFZnEv6JkDK88Y8VsSXZ12"] }
+      it { expect(subject).to eq([]) }
+    end
+  end
+
   describe '#broadcast' do
     subject { adapter.broadcast(wallet.wallet_id, tx) }
     let(:tx) { Tapyrus::Tx.new }

--- a/spec/glueby/internal/wallet/active_record_wallet_adapter_spec.rb
+++ b/spec/glueby/internal/wallet/active_record_wallet_adapter_spec.rb
@@ -398,6 +398,11 @@ RSpec.describe 'Glueby::Internal::Wallet::ActiveRecordWalletAdapter', active_rec
       it { expect { subject }.to raise_error(Glueby::ArgumentError, '"invalidaddress1FnbjGaaHaitz9FwTpDq4Ss8AkeKpLB5YY" is invalid address. Value passed not a valid Base58 String.') }
     end
 
+    context 'invalid version byte address' do
+      let(:addresses) { ['mp4Gq7bucHRNkD52L8wa2Q57MiEZSGsw2a'] }
+      it { expect { subject }.to raise_error(Glueby::ArgumentError, '"mp4Gq7bucHRNkD52L8wa2Q57MiEZSGsw2a" is invalid address. Invalid version bytes.') }
+    end
+
     context 'the addresses are not managed in the wallet' do
       let(:addresses) { ["1Dc9f6MvAKB4L3xhzD61YMgd12JdsGUg6N", "17i5rxVcXsujjFZnEv6JkDK88Y8VsSXZ12"] }
       it { expect(subject).to eq([]) }


### PR DESCRIPTION
We needs to get a list of address information to check the addresses is suitable on some processes.
We're going to use this method on tracking library that needs to check the addresses are tracking address or not.