### PR TITLE
Fix insufficient fee error with bearing fee by wallets

### DIFF
--- a/lib/glueby/contract/timestamp/tx_builder/simple.rb
+++ b/lib/glueby/contract/timestamp/tx_builder/simple.rb
@@ -34,11 +34,11 @@ module Glueby
             if utxo_provider
               @txb.add_utxo_to!(
                 address: @wallet.internal_wallet.receive_address,
-                amount: @txb.dummy_fee,
+                amount: input_amount,
                 utxo_provider: utxo_provider
               )
             else
-              fee = @txb.dummy_fee
+              fee = input_amount
               return self if fee == 0
 
               _, outputs = @wallet.internal_wallet.collect_uncolored_outputs(fee)
@@ -49,6 +49,10 @@ module Glueby
 
           def funding_tx
             @txb.prev_txs.first
+          end
+
+          def input_amount
+            @txb.dummy_fee
           end
         end
       end

--- a/lib/glueby/contract/timestamp/tx_builder/simple.rb
+++ b/lib/glueby/contract/timestamp/tx_builder/simple.rb
@@ -51,6 +51,8 @@ module Glueby
             @txb.prev_txs.first
           end
 
+          private
+
           def input_amount
             @txb.dummy_fee
           end

--- a/lib/glueby/contract/timestamp/tx_builder/trackable.rb
+++ b/lib/glueby/contract/timestamp/tx_builder/trackable.rb
@@ -16,6 +16,12 @@ module Glueby
             @txb.pay(p2c_address, P2C_DEFAULT_VALUE)
             self
           end
+
+          private
+
+          def input_amount
+            super + P2C_DEFAULT_VALUE
+          end
         end
       end
     end

--- a/lib/glueby/internal/contract_builder.rb
+++ b/lib/glueby/internal/contract_builder.rb
@@ -291,7 +291,11 @@ module Glueby
         # fulfill TPC inputs
         in_amount = @incomings[Tapyrus::Color::ColorIdentifier.default] || 0
         out_amount = @outgoings[Tapyrus::Color::ColorIdentifier.default] || 0
-        target_amount = (out_amount + estimate_fee) - in_amount
+        target_amount = if Glueby.configuration.use_utxo_provider?
+                          out_amount - in_amount
+                        else
+                          (out_amount + estimate_fee) - in_amount
+                        end
 
         if target_amount > 0
           auto_fulfill_inputs_utxos_for_tpc(target_amount)

--- a/lib/glueby/internal/contract_builder.rb
+++ b/lib/glueby/internal/contract_builder.rb
@@ -12,7 +12,8 @@ module Glueby
       #                               and it is selected automatically from configuration. If using the UTXO
       #                               Provider is enabled, it uses UTXO Provider. If it's false, an user of
       #                               ContractBuilder need to add UTXOs to pay the fee manually. This behavior
-      #                               works independently of the FeeProvider.
+      #                               works independently of the FeeProvider. If you set use_auto_fulfill_inputs,
+      #                               use_auto_fee option is also enabled automatically.
       # @param [Boolean] use_auto_fulfill_inputs If it's true, inputs for payments are automatically added to fulfill
       #                                          from the sender_wallet. If you create an colored coin issue
       #                                          transaction, you must set this to false or it try to add inputs up
@@ -29,7 +30,7 @@ module Glueby
       )
         @sender_wallet = sender_wallet
         set_fee_estimator(fee_estimator)
-        @use_auto_fee = use_auto_fee
+        @use_auto_fee = use_auto_fulfill_inputs || use_auto_fee
         @use_auto_fulfill_inputs = use_auto_fulfill_inputs
         @use_unfinalized_utxo = use_unfinalized_utxo
         @p2c_utxos = []
@@ -290,11 +291,8 @@ module Glueby
         # fulfill TPC inputs
         in_amount = @incomings[Tapyrus::Color::ColorIdentifier.default] || 0
         out_amount = @outgoings[Tapyrus::Color::ColorIdentifier.default] || 0
-        target_amount = if @use_auto_fee
-                          (out_amount + estimate_fee) - in_amount
-                        else
-                          out_amount - in_amount
-                        end
+        target_amount = (out_amount + estimate_fee) - in_amount
+
         if target_amount > 0
           auto_fulfill_inputs_utxos_for_tpc(target_amount)
             .each { |utxo| add_utxo(utxo) }

--- a/lib/glueby/internal/contract_builder.rb
+++ b/lib/glueby/internal/contract_builder.rb
@@ -419,7 +419,7 @@ module Glueby
 
           tx.outputs << Tapyrus::TxOut.new(
             value: 0,
-            script_pubkey: Tapyrus::Script.new << Tapyrus::Script::OP_RETURN
+            script_pubkey: Tapyrus::Script.new << Tapyrus::Opcodes::OP_RETURN
           )
         end
       end

--- a/lib/glueby/utxo_provider.rb
+++ b/lib/glueby/utxo_provider.rb
@@ -79,9 +79,6 @@ module Glueby
       fee = fee_estimator.fee(Contract::FeeEstimator.dummy_tx(tx, dummy_input_count: 0))
       provided_utxos = []
 
-      # If the change output value is less than DUST_LIMIT, tapyrus core returns "dust" error while broadcasting.
-      target_amount += DUST_LIMIT if target_amount < DUST_LIMIT
-
       while current_amount - fee < target_amount
         sum, utxos = collect_uncolored_outputs(wallet, fee + target_amount - current_amount, provided_utxos)
 

--- a/spec/functional/timestamp_spec.rb
+++ b/spec/functional/timestamp_spec.rb
@@ -68,7 +68,12 @@ RSpec.describe 'Timestamp Contract', functional: true do
           expect(ar.payment_base).to be_nil
 
           # Broadcast tx for the timestamp job
-          # and it should consume one UTXO in UtxoProvider
+          # and it should consume two UTXOs in UtxoProvider
+          # It creates two TXs, the one is funding tx that is created by UTXO Provider to provide a tapyrus input
+          # to the timestamp tx. The funding tx has two inputs from UTXO pool and the input amount is 8000 tapyrus.
+          # The timestamp TX requires 3000 tapyrus, so the funding tx has 4000 tapyrus output to the timestamp tx.
+          # The fee of the funding tx is 2000 tapyrus, this is fixed by FixedFeeEstimator. And the change is 3000
+          # tapyrus to the UTXO Provider's wallet. So, it should consume two UTXOs from UTXO Provider.
           expect do
             Rake.application['glueby:contract:timestamp:create'].execute
           end.to change { Glueby::UtxoProvider.instance.wallet.list_unspent.count }.by(-2)

--- a/spec/functional/timestamp_spec.rb
+++ b/spec/functional/timestamp_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'Timestamp Contract', functional: true do
           # and it should consume one UTXO in UtxoProvider
           expect do
             Rake.application['glueby:contract:timestamp:create'].execute
-          end.to change { Glueby::UtxoProvider.instance.wallet.list_unspent.count }.by(-1)
+          end.to change { Glueby::UtxoProvider.instance.wallet.list_unspent.count }.by(-2)
 
           ar.reload
           expect(sender.balances(false)['']).to be_nil
@@ -102,7 +102,7 @@ RSpec.describe 'Timestamp Contract', functional: true do
           )
           expect do
             Rake.application['glueby:contract:timestamp:create'].execute
-          end.to change { Glueby::UtxoProvider.instance.wallet.list_unspent.count }.by(-1)
+          end.to change { Glueby::UtxoProvider.instance.wallet.list_unspent.count }.by(-2)
 
           update_ar.reload
           # expect(sender.balances(false)['']).to be_nil

--- a/spec/functional/token_spec.rb
+++ b/spec/functional/token_spec.rb
@@ -148,8 +148,14 @@ RSpec.describe 'Token Contract', functional: true do
           expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
           expect(receiver.balances(false)[token.color_id.to_hex]).to eq 1
 
+          receiver_before_balance = receiver.balances(false)['']
+
           token.burn!(sender: receiver, amount: 1, fee_estimator: fee_estimator)
           process_block
+
+          if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+            expect(receiver.balances(false)['']).to eq(receiver_before_balance - fee)
+          end
 
           expect(receiver.balances(false)[token.color_id.to_hex]).to be_nil
         end

--- a/spec/functional/token_spec.rb
+++ b/spec/functional/token_spec.rb
@@ -463,26 +463,18 @@ RSpec.describe 'Token Contract', functional: true do
         expect(receiver.internal_wallet.list_unspent(false).select {|i| i[:color_id] == token.color_id.to_hex}.size).to eq(100)
       end
 
-      it 'raise insufficient error in to much split number' do
+      it 'doesn\'t raise insufficient error in too much split number' do
         expect do
           Glueby::Contract::Token.issue!(
             issuer: sender, token_type: Tapyrus::Color::TokenTypes::REISSUABLE, amount: 10_000, split: 25)
-        end.to raise_error(
-          Tapyrus::RPC::Error,
-          '{"response_code":"500","response_msg":"Internal Server Error","rpc_error":{"code":-26,"message":"min relay fee not met, 2000 \u003c 2051 (code 66)"}}'
-        )
-        # It remains the amount of funding tx to sender's wallet
-        expect(sender.balances(false)['']).to eq(2000)
+        end.not_to raise_error
+        expect(sender.balances(false)['']).to be_nil
 
         expect do
           Glueby::Contract::Token.issue!(
             issuer: sender, token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE, amount: 10_000, split: 25)
-        end.to raise_error(
-          Tapyrus::RPC::Error,
-          '{"response_code":"500","response_msg":"Internal Server Error","rpc_error":{"code":-26,"message":"min relay fee not met, 2000 \u003c 2051 (code 66)"}}'
-        )
-        # It remains the amount of funding tx to sender's wallet
-        expect(sender.balances(false)['']).to eq(4000)
+        end.not_to raise_error
+        expect(sender.balances(false)['']).to be_nil
       end
     end
   end

--- a/spec/functional/token_spec.rb
+++ b/spec/functional/token_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe 'Token Contract', functional: true do
 
     context 'bear fees by sender' do
       let(:fee) { 10_000 }
-      let(:fee_estimator) { Glueby::Contract::FeeEstimator::Fixed.new(fixed_fee: fee) }
       let(:sender) { Glueby::Wallet.create }
       let(:receiver) { Glueby::Wallet.create }
       let(:before_balance) { sender.balances(false)[''] }
@@ -21,113 +20,192 @@ RSpec.describe 'Token Contract', functional: true do
         before_balance
       end
 
-      it 'reissunable token' do
-        expect(Glueby::Contract::AR::ReissuableToken.count).to eq(0)
+      shared_examples 'token contract works correctly bearing fees by sender' do
+        it 'reissunable token' do
+          expect(Glueby::Contract::AR::ReissuableToken.count).to eq(0)
 
-        token, _txs = Glueby::Contract::Token.issue!(
-          issuer: sender, token_type: Tapyrus::Color::TokenTypes::REISSUABLE, amount: 10_000)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance - fee * 2)
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
-        expect(Glueby::Contract::AR::ReissuableToken.count).to eq(1)
-
-        token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: 5_000)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance - fee * 3)
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
-        expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
-
-        token.reissue!(issuer: sender, amount: 5_000)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance - fee * 5)
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
-
-        token.burn!(sender: sender, amount: 10_000)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance - fee * 6)
-        expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
-
-        # If the sending to Tapyrus Core is failure, Glueby::Contract::AR::ReissuableToken should not be created.
-        TapyrusCoreContainer.stop
-        begin
-          Glueby::Contract::Token.issue!(
-            issuer: sender, token_type: Tapyrus::Color::TokenTypes::REISSUABLE, amount: 10_000)
-        rescue Errno::ECONNREFUSED
-          # Ignored
-        end
-        expect(Glueby::Contract::AR::ReissuableToken.count).to eq(1)
-      end
-
-      it 'non-reissunable token' do
-        token, _txs = Glueby::Contract::Token.issue!(
-          issuer: sender, token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE, amount: 10_000)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance - fee * 1)
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
-
-        token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: 5_000)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance - fee * 2)
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
-        expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
-
-        token.burn!(sender: sender, amount: 5_000)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance - fee * 3)
-        expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
-      end
-
-      it 'NFT token' do
-        token, _txs = Glueby::Contract::Token.issue!(issuer: sender, token_type: Tapyrus::Color::TokenTypes::NFT)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance - fee * 1)
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(1)
-
-        token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance - fee * 2)
-        expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
-        expect(receiver.balances(false)[token.color_id.to_hex]).to eq 1
-
-        token.burn!(sender: receiver, amount: 1)
-        process_block
-
-        expect(receiver.balances(false)[token.color_id.to_hex]).to be_nil
-      end
-
-      context 'transfer unconfirmed token' do
-        before do
-          Glueby::AR::SystemInformation.create(
-            info_key: 'use_only_finalized_utxo',
-            info_value: '0'
-          )
-        end
-        it do
           token, _txs = Glueby::Contract::Token.issue!(
-            issuer: sender, token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE, amount: 10_000)
+            issuer: sender,
+            token_type: Tapyrus::Color::TokenTypes::REISSUABLE,
+            amount: 10_000,
+            fee_estimator: fee_estimator
+          )
+          process_block
 
-          expect(sender.balances(false)['']).to eq(before_balance - fee * 1)
+          if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+            expect(sender.balances(false)['']).to eq(before_balance - fee * 2)
+          end
+
           expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
+          expect(Glueby::Contract::AR::ReissuableToken.count).to eq(1)
 
-          token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: 5_000)
+          token.transfer!(
+            sender: sender,
+            receiver_address: receiver.internal_wallet.receive_address,
+            amount: 5_000,
+            fee_estimator: fee_estimator
+          )
+          process_block
 
-          expect(sender.balances(false)['']).to eq(before_balance - fee * 2)
+          if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+            expect(sender.balances(false)['']).to eq(before_balance - fee * 3)
+          end
+
           expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
           expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
 
-          token.burn!(sender: sender, amount: 5_000)
+          token.reissue!(issuer: sender, amount: 5_000, fee_estimator: fee_estimator)
+          process_block
 
-          expect(sender.balances(false)['']).to eq(before_balance - fee * 3)
+          if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+            expect(sender.balances(false)['']).to eq(before_balance - fee * 5)
+          end
+          expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
+
+          token.burn!(sender: sender, amount: 10_000, fee_estimator: fee_estimator)
+          process_block
+
+          if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+            expect(sender.balances(false)['']).to eq(before_balance - fee * 6)
+          end
           expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+
+          # If the sending to Tapyrus Core is failure, Glueby::Contract::AR::ReissuableToken should not be created.
+          TapyrusCoreContainer.stop
+          begin
+            Glueby::Contract::Token.issue!(
+              issuer: sender,
+              token_type: Tapyrus::Color::TokenTypes::REISSUABLE,
+              amount: 10_000,
+              fee_estimator: fee_estimator
+            )
+          rescue Errno::ECONNREFUSED
+            # Ignored
+          end
+          expect(Glueby::Contract::AR::ReissuableToken.count).to eq(1)
+        end
+
+        it 'non-reissunable token' do
+          token, _txs = Glueby::Contract::Token.issue!(
+            issuer: sender,
+            token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE,
+            amount: 10_000,
+            fee_estimator: fee_estimator
+          )
+          process_block
+
+          if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+            expect(sender.balances(false)['']).to eq(before_balance - fee * 1)
+          end
+          expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
+
+          token.transfer!(
+            sender: sender,
+            receiver_address: receiver.internal_wallet.receive_address,
+            amount: 5_000,
+            fee_estimator: fee_estimator
+          )
+          process_block
+
+          if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+            expect(sender.balances(false)['']).to eq(before_balance - fee * 2)
+          end
+          expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
+          expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
+
+          token.burn!(sender: sender, amount: 5_000, fee_estimator: fee_estimator)
+          process_block
+
+          if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+            expect(sender.balances(false)['']).to eq(before_balance - fee * 3)
+          end
+          expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+        end
+
+        it 'NFT token' do
+          token, _txs = Glueby::Contract::Token.issue!(
+            issuer: sender,
+            token_type: Tapyrus::Color::TokenTypes::NFT,
+            fee_estimator: fee_estimator
+          )
+          process_block
+
+          if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+            expect(sender.balances(false)['']).to eq(before_balance - fee * 1)
+          end
+          expect(sender.balances(false)[token.color_id.to_hex]).to eq(1)
+
+          token.transfer!(
+            sender: sender,
+            receiver_address: receiver.internal_wallet.receive_address,
+            fee_estimator: fee_estimator
+          )
+          process_block
+
+          if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+            expect(sender.balances(false)['']).to eq(before_balance - fee * 2)
+          end
+          expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+          expect(receiver.balances(false)[token.color_id.to_hex]).to eq 1
+
+          token.burn!(sender: receiver, amount: 1, fee_estimator: fee_estimator)
+          process_block
+
+          expect(receiver.balances(false)[token.color_id.to_hex]).to be_nil
+        end
+
+        context 'transfer unconfirmed token' do
+          before do
+            Glueby::AR::SystemInformation.create(
+              info_key: 'use_only_finalized_utxo',
+              info_value: '0'
+            )
+          end
+          it do
+            token, _txs = Glueby::Contract::Token.issue!(
+              issuer: sender,
+              token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE,
+              amount: 10_000,
+              fee_estimator: fee_estimator
+            )
+
+            if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+              expect(sender.balances(false)['']).to eq(before_balance - fee * 1)
+            end
+            expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
+
+            token.transfer!(
+              sender: sender,
+              receiver_address: receiver.internal_wallet.receive_address,
+              amount: 5_000,
+              fee_estimator: fee_estimator
+            )
+
+            if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+              expect(sender.balances(false)['']).to eq(before_balance - fee * 2)
+            end
+            expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
+            expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
+
+            token.burn!(sender: sender, amount: 5_000, fee_estimator: fee_estimator)
+
+            if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+              expect(sender.balances(false)['']).to eq(before_balance - fee * 3)
+            end
+            expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+          end
+        end
+      end
+
+      context 'fee estimator is Fixed' do
+        it_behaves_like 'token contract works correctly bearing fees by sender' do
+          let(:fee_estimator) { Glueby::Contract::FeeEstimator::Fixed.new(fixed_fee: fee) }
+        end
+      end
+
+      context 'fee estimator is Auto' do
+        it_behaves_like 'token contract works correctly bearing fees by sender' do
+          let(:fee_estimator) { Glueby::Contract::FeeEstimator::Auto.new }
         end
       end
     end

--- a/spec/glueby/contract/token_spec.rb
+++ b/spec/glueby/contract/token_spec.rb
@@ -558,6 +558,9 @@ RSpec.describe 'Glueby::Contract::Token', active_record: true do
 
         it 'has one output for to be a standard tx' do
           expect(internal_wallet).to receive(:broadcast).once do |tx|
+            # Inputs: 2 colored input(200_000 token), 1 uncolored inputs(1_000 tapyrus)
+            # Outputs: 1 OP_RETURN output.
+            # It never create TPC change output because of the change(that is 550) is less than DUST_LIMIT 600.
             expect(tx.inputs.count).to eq(3)
             expect(tx.outputs.count).to eq(1)
             expect(tx.outputs[0].value).to eq(0)

--- a/spec/glueby/contract/token_spec.rb
+++ b/spec/glueby/contract/token_spec.rb
@@ -543,11 +543,12 @@ RSpec.describe 'Glueby::Contract::Token', active_record: true do
 
       it do
         expect(internal_wallet).to receive(:broadcast).once do |tx|
-          # 1 colored input(100_000 token), 2 uncolored inputs(2_000 tapyrus)
-          expect(tx.inputs.count).to eq 3
-          expect(tx.outputs.count).to eq(2)
+          # 1 colored input(100_000 token), 1 uncolored inputs(1_000 tapyrus)
+          # Fee is 450 tapyrus, so 550 tapyrus is change. But the change amount is less than DUST_LIMIT, so the change
+          # output is not created. 550 tapyrus is also pay as fee.
+          expect(tx.inputs.count).to eq(2)
+          expect(tx.outputs.count).to eq(1)
           expect(tx.outputs[0].value).to eq(50_000)
-          expect(tx.outputs[1].value).to eq(1550)
         end
         subject
       end
@@ -557,10 +558,10 @@ RSpec.describe 'Glueby::Contract::Token', active_record: true do
 
         it 'has one output for to be a standard tx' do
           expect(internal_wallet).to receive(:broadcast).once do |tx|
-            # 2 colored input(200_000 token), 2 uncolored inputs(2_000 tapyrus)
-            expect(tx.inputs.count).to eq 4
+            expect(tx.inputs.count).to eq(3)
             expect(tx.outputs.count).to eq(1)
-            expect(tx.outputs[0].value).to eq(1550)
+            expect(tx.outputs[0].value).to eq(0)
+            expect(tx.outputs[0].script_pubkey.op_return?).to be_truthy
           end
           subject
         end
@@ -572,11 +573,14 @@ RSpec.describe 'Glueby::Contract::Token', active_record: true do
 
         it 'has one output for to be a standard tx' do
           expect(internal_wallet).to receive(:broadcast).once do |tx|
-            # Need 1_001 tapyrus at least, that means 401 tapyrus for tx fee, and 600 tapyrus to avoiding "dust limit error"
-            # 1 colored input(100_000 token), 2 uncolored inputs(1_000 * 2 tapyrus)
-            expect(tx.inputs.count).to eq 3
+            # It funds 1_000 tapyrus to the TX and fee is 401 tapyrus. So the rest 599 tapyrus is change amount.
+            # But less than DUST_LIMIT(600 tapyrus) can not be output value because of Tapyrus Core's dust output
+            # policy. So, here will not create change output. All the remain TPC will be payed as fee.
+            # And the TX has dummy output that has 0 value and OP_RETURN script.
+            expect(tx.inputs.count).to eq(2)
             expect(tx.outputs.count).to eq(1)
-            expect(tx.outputs[0].value).to eq(1_599)
+            expect(tx.outputs[0].value).to eq(0)
+            expect(tx.outputs[0].script_pubkey.op_return?).to be_truthy
           end
           subject
         end


### PR DESCRIPTION
トークンの送金トランザクションで、手数料を計算するために利用する一時的なトランザクションにトークンのお釣りのためのアウトプットが追加されないために、手数料が不足するTXを作成していました。
これを修正します。