### PR TITLE
Use auto fulfil inputs feature in token issue and transfer

### DIFF
--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -112,7 +112,7 @@ module Glueby
           txb = Internal::ContractBuilder.new(
             sender_wallet: issuer.internal_wallet,
             fee_estimator: fee_estimator,
-            use_auto_fee: Glueby.configuration.use_utxo_provider? # FIXME: Use the auto fee feature even if it does not use the utxo provider.
+            use_auto_fulfill_inputs: true
           )
 
           if metadata
@@ -185,7 +185,7 @@ module Glueby
           txb = Internal::ContractBuilder.new(
             sender_wallet: issuer.internal_wallet,
             fee_estimator: fee_estimator,
-            use_auto_fee: Glueby.configuration.use_utxo_provider? # FIXME: Use the auto fee feature even if it does not use the utxo provider.
+            use_auto_fulfill_inputs: true
           )
 
           funding_tx = nil
@@ -281,7 +281,7 @@ module Glueby
         txb = Internal::ContractBuilder.new(
           sender_wallet: issuer.internal_wallet,
           fee_estimator: fee_estimator,
-          use_auto_fee: Glueby.configuration.use_utxo_provider? # FIXME: Use the auto fee feature even if it does not use the utxo provider.
+          use_auto_fulfill_inputs: true
         )
 
         if token_metadata


### PR DESCRIPTION
We are going to remove use_auto_fee option in `ContractBulder`. The functionality of use_auto_fee is going to be included to auto_fulfill_inputs feature.

~This PR includes the difference of #170. After #170 merged, this PR will be rebased on the master HEAD and turn into normal PR from draft.~