### PR TITLE
Fix duplicate inputs error

### DIFF
--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -207,12 +207,9 @@ module Glueby
             )
             funding_tx = txb.prev_txs.first
           else
-            # It does not create funding tx if metadata is not given and utxo provider is not used.
-            fee = fee_estimator.fee(dummy_issue_tx_from_out_point)
-
-            # FIXME: It is enough to add just one UTXO here. But, here add all UTXOs in issuer's wallet, if fee provider is enabled.
-            _, outputs = issuer.internal_wallet.collect_uncolored_outputs(fee == 0 ? nil : fee, nil, true)
-            outputs.each { |utxo| txb.add_utxo(utxo) }
+            # Here need to add just one UTXO to derive color_id from the UTXO out-point.
+            _, outputs = issuer.internal_wallet.collect_uncolored_outputs(1, nil, true)
+            txb.add_utxo(outputs.first)
           end
 
           utxo = txb.utxos.first

--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -210,7 +210,7 @@ module Glueby
             # It does not create funding tx if metadata is not given and utxo provider is not used.
             fee = fee_estimator.fee(dummy_issue_tx_from_out_point)
 
-            # FIXME: It is enough to add just one UTXO here. Funding for fee should care by use_auto_fee feature. But, here add all UTXOs in issuer's wallet, if fee provider is enabled.
+            # FIXME: It is enough to add just one UTXO here. But, here add all UTXOs in issuer's wallet, if fee provider is enabled.
             _, outputs = issuer.internal_wallet.collect_uncolored_outputs(fee == 0 ? nil : fee, nil, true)
             outputs.each { |utxo| txb.add_utxo(utxo) }
           end

--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -349,7 +349,6 @@ module Glueby
                   sender_wallet: sender.internal_wallet,
                   fee_estimator: fee_estimator,
                   use_unfinalized_utxo: !only_finalized?,
-                  use_auto_fee: true,
                   use_auto_fulfill_inputs: true
                 )
                 .change_address(sender.internal_wallet.receive_address, color_id)
@@ -382,7 +381,6 @@ module Glueby
                   sender_wallet: sender.internal_wallet,
                   fee_estimator: fee_estimator,
                   use_unfinalized_utxo: !only_finalized?,
-                  use_auto_fee: true,
                   use_auto_fulfill_inputs: true
                 )
                 .burn(amount, color_id)

--- a/lib/glueby/internal/contract_builder.rb
+++ b/lib/glueby/internal/contract_builder.rb
@@ -1,8 +1,7 @@
 module Glueby
   module Internal
     class ContractBuilder < Tapyrus::TxBuilder
-      attr_reader :fee_estimator, :sender_wallet, :prev_txs, :p2c_utxos, :use_unfinalized_utxo, :use_auto_fee,
-                  :use_auto_fulfill_inputs
+      attr_reader :fee_estimator, :sender_wallet, :prev_txs, :p2c_utxos, :use_unfinalized_utxo, :use_auto_fulfill_inputs
 
       # @param [Glueby::Internal::Wallet] sender_wallet The wallet that is an user's wallet who send the transaction
       #                                                 to a blockchain.
@@ -19,7 +18,6 @@ module Glueby
       def initialize(
         sender_wallet:,
         fee_estimator: :auto,
-        use_auto_fee: false,
         use_auto_fulfill_inputs: false,
         use_unfinalized_utxo: false
       )

--- a/lib/glueby/internal/contract_builder.rb
+++ b/lib/glueby/internal/contract_builder.rb
@@ -7,17 +7,12 @@ module Glueby
       # @param [Glueby::Internal::Wallet] sender_wallet The wallet that is an user's wallet who send the transaction
       #                                                 to a blockchain.
       # @param [Symbol|Glueby::Contract::FeeEstimator] fee_estimator :auto or :fixed
-      # @param [Boolean] use_auto_fee If it's true, inputs are automatically added to fulfill the fee.
-      #                               The TPC for the fee is supply from the sender_wallet or UtxoProvider
-      #                               and it is selected automatically from configuration. If using the UTXO
-      #                               Provider is enabled, it uses UTXO Provider. If it's false, an user of
-      #                               ContractBuilder need to add UTXOs to pay the fee manually. This behavior
-      #                               works independently of the FeeProvider. If you set use_auto_fulfill_inputs,
-      #                               use_auto_fee option is also enabled automatically.
-      # @param [Boolean] use_auto_fulfill_inputs If it's true, inputs for payments are automatically added to fulfill
-      #                                          from the sender_wallet. If you create an colored coin issue
-      #                                          transaction, you must set this to false or it try to add inputs up
-      #                                          to the issue amount. The default value is false.
+      # @param [Boolean] use_auto_fulfill_inputs
+      #   If it's true, inputs are automatically added up to fulfill the TPC and tokens requirement that is added by
+      #   #pay and #burn. The option also support to fill adding TPC inputs for paying fee.
+      #   If Glueby.configuration.use_utxo_provider? is true, All the TPC inputs are added from the UtxoProvider's
+      #   wallet. It it's false, all the TPC inputs are from sender_wallet.
+      #   If Glueby.configuration.fee_provider_bears? is true, it won't add TPC amount for fee.
       # @param [Boolean] use_unfinalized_utxo If it's true, The ContractBuilder use unfinalized UTXO that is not
       #                                       included in the block in its inputs.
       # @raise [Glueby::ArgumentError] If the fee_estimator is not :auto or :fixed
@@ -30,7 +25,6 @@ module Glueby
       )
         @sender_wallet = sender_wallet
         set_fee_estimator(fee_estimator)
-        @use_auto_fee = use_auto_fulfill_inputs || use_auto_fee
         @use_auto_fulfill_inputs = use_auto_fulfill_inputs
         @use_unfinalized_utxo = use_unfinalized_utxo
         @p2c_utxos = []
@@ -213,26 +207,21 @@ module Glueby
 
       alias :original_build :build
       def build
-        auto_fulfill_inputs if use_auto_fulfill_inputs
+        auto_fulfill_inputs_utxos_for_color if use_auto_fulfill_inputs
 
         tx = Tapyrus::Tx.new
-
         set_tpc_change_address
-        auto_fee_with_sender_wallet if @use_auto_fee && !Glueby.configuration.use_utxo_provider?
-
         expand_input(tx)
         @outputs.each { |output| tx.outputs << output }
-
         add_change_for_colored_coin(tx)
 
-        if @use_auto_fee && Glueby.configuration.use_utxo_provider?
-          auto_fee_with_utxo_provider(tx)
+        if use_auto_fulfill_inputs
+          auto_fulfill_inputs_utxos_for_tpc(tx)
         else
           add_change_for_tpc(tx)
         end
 
         add_dummy_output(tx)
-
         sign(tx)
       end
 
@@ -319,72 +308,16 @@ module Glueby
         tx
       end
 
-      def auto_fulfill_inputs
-        # fulfill TPC inputs
-        in_amount = @incomings[Tapyrus::Color::ColorIdentifier.default] || 0
-        out_amount = @outgoings[Tapyrus::Color::ColorIdentifier.default] || 0
-        target_amount = if Glueby.configuration.use_utxo_provider?
-                          out_amount - in_amount
-                        else
-                          (out_amount + estimate_fee) - in_amount
-                        end
-
-        if target_amount > 0
-          auto_fulfill_inputs_utxos_for_tpc(target_amount)
-            .each { |utxo| add_utxo(utxo) }
-        end
-
-        # fulfill colored inputs
-        @outgoings.each do |color_id, outgoing_amount|
-          next if color_id.default?
-
-          target_amount = outgoing_amount - (@incomings[color_id] || 0) - @issues[color_id]
-          next if target_amount <= 0
-
-          auto_fulfill_inputs_utxos_for_color(color_id, target_amount)
-            .each { |utxo| add_utxo(utxo) }
-        end
-      end
-
-      def auto_fulfill_inputs_utxos_for_tpc(target_amount)
-        wallet = if Glueby.configuration.use_utxo_provider?
-                   Glueby::UtxoProvider.instance.wallet
-                 else
-                   @sender_wallet
-                 end
-        wallet.collect_uncolored_outputs(
-          target_amount,
-          nil,
-          use_only_finalized_utxo,
-          true
-        )[1]
-      end
-
-      def auto_fulfill_inputs_utxos_for_color(color_id, target_amount)
-        @sender_wallet.collect_colored_outputs(
-          color_id,
-          target_amount,
-          nil,
-          use_only_finalized_utxo,
-          true
-        )[1]
-      end
-
-      def get_fee_estimator(fee_estimator_name)
-        Glueby::Contract::FeeEstimator.get_const("#{fee_estimator_name.capitalize}", false).new
-      end
-
-      def valid_fee_estimator?(fee_estimator)
-        [:fixed, :auto].include?(fee_estimator)
-      end
-
-      def auto_fee_with_utxo_provider(tx)
-        # If fee_provider_bears is true, estimated_fee is 0.
-        return if estimated_fee == 0
-
-        utxo_provider = UtxoProvider.instance
+      def auto_fulfill_inputs_utxos_for_tpc(tx)
         target_amount = @outgoings[Tapyrus::Color::ColorIdentifier.default] || 0
-        tx, fee, tpc_amount, provided_utxos = utxo_provider.fill_inputs(
+
+        provider = if Glueby.configuration.use_utxo_provider?
+                     UtxoProvider.instance
+                   else
+                     sender_wallet
+                   end
+
+        tx, fee, tpc_amount, provided_utxos = provider.fill_uncolored_inputs(
           tx,
           target_amount: target_amount,
           current_amount: @incomings[Tapyrus::Color::ColorIdentifier.default] || 0,
@@ -393,25 +326,41 @@ module Glueby
 
         change = tpc_amount - target_amount - fee
 
-        if change >= DUST_LIMIT
-          change_script = Tapyrus::Script.parse_from_addr(utxo_provider.wallet.change_address)
+        change_script = Tapyrus::Script.parse_from_addr(provider.change_address)
+        output = Tapyrus::TxOut.new(value: change, script_pubkey: change_script)
+        unless output.dust?
           tx.outputs << Tapyrus::TxOut.new(value: change, script_pubkey: change_script)
         end
 
-        utxo_provider.wallet.sign_tx(tx, provided_utxos)
+        provider.wallet.sign_tx(tx, provided_utxos) if Glueby.configuration.use_utxo_provider?
       end
 
-      def auto_fee_with_sender_wallet
-        # If it uses auto fulfill inputs feature, #auto_fulfill_inputs method adds TPC UTXOs includes fee.
-        return if @use_auto_fulfill_inputs
+      def auto_fulfill_inputs_utxos_for_color
+        # fulfill colored inputs
+        @outgoings.each do |color_id, outgoing_amount|
+          next if color_id.default?
 
-        # FIXME: If fee is 0, here add all TPC UTXOs in the issuer wallet. If the estimated_fee is zero, here should do nothing.
-        amount = estimated_fee == 0 ? nil : estimated_fee
+          target_amount = outgoing_amount - (@incomings[color_id] || 0) - @issues[color_id]
+          next if target_amount <= 0
 
-        # TODO: Support the case of increasing fee by adding multiple inputs
-        _, outputs = sender_wallet
-                       .collect_uncolored_outputs(amount, nil, use_only_finalized_utxo)
-        outputs.each { |o| add_utxo(o) }
+          @sender_wallet.collect_colored_outputs(
+            color_id,
+            target_amount,
+            nil,
+            use_only_finalized_utxo,
+            true
+          )[1]
+            .each { |utxo| add_utxo(utxo) }
+        end
+
+      end
+
+      def get_fee_estimator(fee_estimator_name)
+        Glueby::Contract::FeeEstimator.get_const("#{fee_estimator_name.capitalize}", false).new
+      end
+
+      def valid_fee_estimator?(fee_estimator)
+        [:fixed, :auto].include?(fee_estimator)
       end
 
       def use_only_finalized_utxo

--- a/lib/glueby/internal/wallet.rb
+++ b/lib/glueby/internal/wallet.rb
@@ -151,7 +151,10 @@ module Glueby
       # @param [String] label The label of UTXO to collect
       # @param [Boolean] only_finalized The flag to collect only finalized UTXO
       # @param [Boolean] shuffle The flag to shuffle UTXO before collecting
-      # @return [Array<Hash>] The array of UTXO
+      # @param [Boolean] lock_utxos The flag to lock returning UTXOs to prevent to be used from other threads or processes
+      # @param [Array<Hash] excludes The UTXO list to exclude the method result. Each hash must hub keys that are :txid and :vout
+      # @return [Integer] The sum of return UTOXs
+      # @return [Array<Hash>] An array of UTXO hash
       #
       # ## The UTXO structure
       #
@@ -182,7 +185,10 @@ module Glueby
       # @param [String] label The label of UTXO to collect
       # @param [Boolean] only_finalized The flag to collect only finalized UTXO
       # @param [Boolean] shuffle The flag to shuffle UTXO before collecting
-      # @return [Array<Hash>] The array of UTXO
+      # @param [Boolean] lock_utxos The flag to lock returning UTXOs to prevent to be used from other threads or processes
+      # @param [Array<Hash] excludes The UTXO list to exclude the method result. Each hash must hub keys that are :txid and :vout
+      # @return [Integer] The sum of return UTOXs
+      # @return [Array<Hash>] An array of UTXO hash
       #
       # ## The UTXO structure
       #
@@ -197,10 +203,10 @@ module Glueby
         label = nil,
         only_finalized = true,
         shuffle = false,
-        lock_utoxs = false,
+        lock_utxos = false,
         excludes = []
       )
-        collect_utxos(amount, label, only_finalized, shuffle, lock_utoxs, excludes) do |output|
+        collect_utxos(amount, label, only_finalized, shuffle, lock_utxos, excludes) do |output|
           next false unless output[:color_id] == color_id.to_hex
           next yield(output) if block_given?
 
@@ -285,7 +291,7 @@ module Glueby
         only_finalized,
         shuffle = true,
         lock_utxos = false,
-        excludes = nil
+        excludes = []
       )
         collect_all = amount.nil?
 
@@ -294,7 +300,9 @@ module Glueby
         utxos = utxos.shuffle if shuffle
 
         r = utxos.inject([0, []]) do |(sum, outputs), output|
-          if excludes.is_a?(Array) && excludes.find { |i| i[:txid] == output[:txid] && i[:vout] == output[:vout] }
+          if excludes.is_a?(Array) &&
+            !excludes.empty? &&
+            excludes.find { |i| i[:txid] == output[:txid] && i[:vout] == output[:vout] }
             next [sum, outputs]
           end
 

--- a/lib/glueby/internal/wallet.rb
+++ b/lib/glueby/internal/wallet.rb
@@ -153,7 +153,7 @@ module Glueby
       # @param [Boolean] shuffle The flag to shuffle UTXO before collecting
       # @param [Boolean] lock_utxos The flag to lock returning UTXOs to prevent to be used from other threads or processes
       # @param [Array<Hash] excludes The UTXO list to exclude the method result. Each hash must hub keys that are :txid and :vout
-      # @return [Integer] The sum of return UTOXs
+      # @return [Integer] The sum of return UTXOs
       # @return [Array<Hash>] An array of UTXO hash
       #
       # ## The UTXO structure
@@ -187,7 +187,7 @@ module Glueby
       # @param [Boolean] shuffle The flag to shuffle UTXO before collecting
       # @param [Boolean] lock_utxos The flag to lock returning UTXOs to prevent to be used from other threads or processes
       # @param [Array<Hash] excludes The UTXO list to exclude the method result. Each hash must hub keys that are :txid and :vout
-      # @return [Integer] The sum of return UTOXs
+      # @return [Integer] The sum of return UTXOs
       # @return [Array<Hash>] An array of UTXO hash
       #
       # ## The UTXO structure

--- a/lib/glueby/internal/wallet.rb
+++ b/lib/glueby/internal/wallet.rb
@@ -160,9 +160,19 @@ module Glueby
       # - amount: [Integer] Amount of the UTXO as tapyrus unit
       # - finalized: [Boolean] Whether the UTXO is finalized
       # - script_pubkey: [String] ScriptPubkey of the UTXO
-      def collect_uncolored_outputs(amount = nil, label = nil, only_finalized = true, shuffle = false)
-        collect_utxos(amount, label, only_finalized, shuffle) do |output|
-          output[:color_id].nil?
+      def collect_uncolored_outputs(
+        amount = nil,
+        label = nil,
+        only_finalized = true,
+        shuffle = false,
+        lock_utxos = false,
+        excludes = []
+      )
+        collect_utxos(amount, label, only_finalized, shuffle, lock_utxos, excludes) do |output|
+          next false unless output[:color_id].nil?
+          next yield(output) if block_given?
+
+          true
         end
       end
 
@@ -181,9 +191,20 @@ module Glueby
       # - amount: [Integer] Amount of the UTXO as tapyrus unit
       # - finalized: [Boolean] Whether the UTXO is finalized
       # - script_pubkey: [String] ScriptPubkey of the UTXO
-      def collect_colored_outputs(color_id, amount = nil, label = nil, only_finalized = true, shuffle = false)
-        collect_utxos(amount, label, only_finalized, shuffle) do |output|
-          output[:color_id] == color_id.to_hex
+      def collect_colored_outputs(
+        color_id,
+        amount = nil,
+        label = nil,
+        only_finalized = true,
+        shuffle = false,
+        lock_utoxs = false,
+        excludes = []
+      )
+        collect_utxos(amount, label, only_finalized, shuffle, lock_utoxs, excludes) do |output|
+          next false unless output[:color_id] == color_id.to_hex
+          next yield(output) if block_given?
+
+          true
         end
       rescue Glueby::Contract::Errors::InsufficientFunds
         raise Glueby::Contract::Errors::InsufficientTokens
@@ -209,27 +230,87 @@ module Glueby
         wallet_adapter.has_address?(id, address)
       end
 
+      # Fill inputs in the tx up to target_amount of TPC from UTXOs in the wallet.
+      # This method should be called before adding change output and script_sig in outputs.
+      # FeeEstimator.dummy_tx returns fee amount to the TX that will be added one TPC input, a change TPC output and
+      # script sigs in outputs.
+      # @param [Tapyrus::Tx] tx The tx that will be filled the inputs
+      # @param [Integer] target_amount The tapyrus amount the tx is expected to be added in this method
+      # @param [Integer] current_amount The tapyrus amount the tx already has in its inputs
+      # @param [Glueby::Contract::FeeEstimator] fee_estimator
+      # @return [Tapyrus::Tx] tx The tx that is added inputs
+      # @return [Integer] fee The final fee after the inputs are filled
+      # @return [Integer] current_amount The final amount of the tx inputs
+      # @return [Array<Hash>] provided_utxos The utxos that are added to the tx inputs
+      def fill_uncolored_inputs(
+        tx,
+        target_amount: ,
+        current_amount: 0,
+        fee_estimator: Contract::FeeEstimator::Fixed.new,
+        &block
+      )
+        fee = fee_estimator.fee(Contract::FeeEstimator.dummy_tx(tx, dummy_input_count: 0))
+        provided_utxos = []
+
+        while current_amount - fee < target_amount
+          sum, utxos = collect_uncolored_outputs(
+            fee + target_amount - current_amount,
+            nil, nil, true, true,
+            provided_utxos,
+            &block
+          )
+
+          utxos.each do |utxo|
+            tx.inputs << Tapyrus::TxIn.new(out_point: Tapyrus::OutPoint.from_txid(utxo[:txid], utxo[:vout]))
+            provided_utxos << utxo
+          end
+          current_amount += sum
+
+          new_fee = fee_estimator.fee(Contract::FeeEstimator.dummy_tx(tx, dummy_input_count: 0))
+          fee = new_fee
+        end
+
+        [tx, fee, current_amount, provided_utxos]
+      end
+
       private
 
       def wallet_adapter
         self.class.wallet_adapter
       end
 
-      def collect_utxos(amount, label, only_finalized, shuffle)
+      def collect_utxos(
+        amount,
+        label,
+        only_finalized,
+        shuffle = true,
+        lock_utxos = false,
+        excludes = nil
+      )
         collect_all = amount.nil?
 
         raise Glueby::ArgumentError, 'amount must be positive' unless collect_all || amount.positive?
         utxos = list_unspent(only_finalized, label)
-        utxos.shuffle! if shuffle
+        utxos = utxos.shuffle if shuffle
 
-        r = utxos.inject([0, []]) do |sum, output|
-          next sum unless yield(output)
+        r = utxos.inject([0, []]) do |(sum, outputs), output|
+          if excludes.is_a?(Array) && excludes.find { |i| i[:txid] == output[:txid] && i[:vout] == output[:vout] }
+            next [sum, outputs]
+          end
 
-          new_sum = sum[0] + output[:amount]
-          new_outputs = sum[1] << output
-          return [new_sum, new_outputs] unless collect_all || new_sum < amount
+          if block_given?
+            next [sum, outputs] unless yield(output)
+          end
 
-          [new_sum, new_outputs]
+          if lock_utxos
+            next [sum, outputs] unless lock_unspent(output)
+          end
+
+          sum += output[:amount]
+          outputs << output
+          return [sum, outputs] unless collect_all || sum < amount
+
+          [sum, outputs]
         end
         raise Glueby::Contract::Errors::InsufficientFunds unless collect_all
 

--- a/spec/glueby/contract/token_spec.rb
+++ b/spec/glueby/contract/token_spec.rb
@@ -544,7 +544,7 @@ RSpec.describe 'Glueby::Contract::Token', active_record: true do
       it do
         expect(internal_wallet).to receive(:broadcast).once do |tx|
           # 1 colored input(100_000 token), 1 uncolored inputs(1_000 tapyrus)
-          # Fee is 450 tapyrus, so 550 tapyrus is change. But the change amount is less than 546, so the change
+          # Fee is 455 tapyrus, so 545 tapyrus is change. But the change amount is less than 546, so the change
           # output is not created. 550 tapyrus is also pay as fee.
           expect(tx.inputs.count).to eq(2)
           expect(tx.outputs.count).to eq(1)

--- a/spec/glueby/internal/contract_builder/auto_fee_spec.rb
+++ b/spec/glueby/internal/contract_builder/auto_fee_spec.rb
@@ -1,19 +1,17 @@
 require_relative '../../../support/contract_builder_test_support'
 
 RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
-  describe 'auto fee feature' do
+  describe 'auto fulfill inputs for fee' do
     let(:instance) do
       described_class.new(
         sender_wallet: sender_wallet,
         fee_estimator: fee_estimator,
-        use_auto_fee: true,
-        use_auto_fulfill_inputs: use_auto_fulfill_inputs,
+        use_auto_fulfill_inputs: true,
         use_unfinalized_utxo: use_unfinalized_utxo
       )
     end
     let(:sender_wallet) { Glueby::Internal::Wallet.create }
     let(:fee_estimator) { Glueby::Contract::FeeEstimator::Fixed.new }
-    let(:use_auto_fulfill_inputs) { false }
     let(:use_unfinalized_utxo) { false }
 
     let(:valid_script_pubkey_hex) { valid_script_pubkey.to_hex }
@@ -48,9 +46,7 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
 
           it 'just add a input for fee and a change output' do
             expect { subject }.not_to raise_error
-            # It have 2 inputs, 1 by #add_utxo and 1 by #auto_fee_with_sender_wallet
-            # FIXME: But, the input by #auto_fee_with_sender_wallet is unnecessary because the input by #add_utxo is enough to pay fee.
-            expect(subject.inputs.size).to eq(2)
+            expect(subject.inputs.size).to eq(1)
             expect(subject.outputs.size).to eq(2)
             expect(fee_estimator.fee(subject)).to eq(219)
             # input amount is 2600, outgoing value is 600, fee is 219, so change is 1781
@@ -194,6 +190,7 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
 
           it 'just add a change output' do
             expect { subject }.not_to raise_error
+            p subject.to_hex
             expect(subject.inputs.size).to eq(1)
             expect(subject.outputs.size).to eq(2)
             expect(fee_estimator.fee(subject)).to eq(219)

--- a/spec/glueby/internal/contract_builder/auto_fee_spec.rb
+++ b/spec/glueby/internal/contract_builder/auto_fee_spec.rb
@@ -52,13 +52,13 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
             # FIXME: But, the input by #auto_fee_with_sender_wallet is unnecessary because the input by #add_utxo is enough to pay fee.
             expect(subject.inputs.size).to eq(2)
             expect(subject.outputs.size).to eq(2)
-            expect(fee_estimator.fee(subject)).to eq(360)
-            # input amount is 3600, outgoing value is 600, fee is 360, so change is 2640
-            expect(subject.outputs[1].value).to eq(2_640)
+            expect(fee_estimator.fee(subject)).to eq(219)
+            # input amount is 2600, outgoing value is 600, fee is 219, so change is 1781
+            expect(subject.outputs[1].value).to eq(1781)
           end
         end
 
-        context 'change amount is less than DUST_LIMIT' do
+        context 'change amount is less than dust threshold to the change output' do
           before do
             instance.pay(valid_address, 600)
                     .add_utxo({
@@ -69,16 +69,14 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
                     })
           end
 
-          it 'add change output' do
+          it 'doesn\'t add a change output' do
+            # input amount is 1000, outgoing value is 600, fee is 185, change will be 215, but the change amount is
+            # less than dust threshold 546.
             expect { subject }.not_to raise_error
-            # It have 2 inputs, 1 by #add_utxo and 1 by #auto_fee_with_sender_wallet
-            # FIXME: But, the input by #auto_fee_with_sender_wallet is unnecessary because the input by #add_utxo is enough to pay fee.
-            expect(subject.inputs.size).to eq(2)
-            expect(subject.outputs.size).to eq(2)
+            expect(subject.inputs.size).to eq(1)
+            expect(subject.outputs.size).to eq(1)
             expect(subject.outputs[0].value).to eq(600)
-            expect(fee_estimator.fee(subject)).to eq(360)
-            # input amount is 2000, outgoing value is 600, fee is 360, so change is 1040
-            expect(subject.outputs[1].value).to eq(1040)
+            expect(fee_estimator.fee(subject)).to eq(185)
           end
         end
 
@@ -120,16 +118,14 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
 
           it 'just add a input for fee and a change output' do
             expect { subject }.not_to raise_error
-            # It have 2 inputs, 1 by #add_utxo and 1 by #auto_fee_with_sender_wallet
-            # FIXME: But, the input by #auto_fee_with_sender_wallet is unnecessary because the input by #add_utxo is enough to pay fee.
-            expect(subject.inputs.size).to eq(2)
+            expect(subject.inputs.size).to eq(1)
             expect(subject.outputs.size).to eq(2)
-            # input amount is 3600, outgoing value is 600, fee is 1000, so change is 2000
-            expect(subject.outputs[1].value).to eq(2_000)
+            # input amount is 2600, outgoing value is 600, fee is 1000, so change is 1000
+            expect(subject.outputs[1].value).to eq(1_000)
           end
         end
 
-        context 'change amount is less than DUST_LIMIT' do
+        context 'change amount is less than dust threshold to the change output' do
           before do
             instance.pay(valid_address, 600)
                     .add_utxo({
@@ -140,15 +136,13 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
                     })
           end
 
-          it 'add change output' do
+          it 'doesn\'t add a change output' do
+            # input amount is 2000, outgoing value is 600, fee is 1000, so change is 400.
+            # But the change value is less than dust threshold 546. So the change output won't add.
             expect { subject }.not_to raise_error
-            # It have 2 inputs, 1 by #add_utxo and 1 by #auto_fee_with_sender_wallet
-            # FIXME: But, the input by #auto_fee_with_sender_wallet is unnecessary because the input by #add_utxo is enough to pay fee.
-            expect(subject.inputs.size).to eq(2)
-            expect(subject.outputs.size).to eq(2)
+            expect(subject.inputs.size).to eq(1)
+            expect(subject.outputs.size).to eq(1)
             expect(subject.outputs[0].value).to eq(600)
-            # input amount is 3000, outgoing value is 600, fee is 1000, so change is 1400
-            expect(subject.outputs[1].value).to eq(1400)
           end
         end
 
@@ -208,7 +202,7 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
           end
         end
 
-        context 'change amount is less than DUST_LIMIT' do
+        context 'change amount is less than dust threshold' do
           before do
             instance.pay(valid_address, 600)
                     .add_utxo({
@@ -223,7 +217,7 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
             expect { subject }.not_to raise_error
             expect(subject.inputs.size).to eq(1)
             # input amount is 1000, outgoing value is 600, fee is 185, so change is 215.
-            # but the change amount is less than DUST_LIMIT 600, so it doesn't add change output.
+            # but the change amount is less than dust threshold 546, so it doesn't add change output.
             expect(subject.outputs.size).to eq(1)
             expect(fee_estimator.fee(subject)).to eq(185)
             expect(subject.outputs[0].value).to eq(600)
@@ -276,7 +270,7 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
           end
         end
 
-        context 'change amount is less than DUST_LIMIT' do
+        context 'change amount is less than dust threshold' do
           before do
             instance.pay(valid_address, 600)
                     .add_utxo({
@@ -291,7 +285,7 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
             expect { subject }.not_to raise_error
             expect(subject.inputs.size).to eq(1)
             # input amount is 2000, outgoing value is 600, fee is 1000, so change is 400.
-            # but the change amount is less than DUST_LIMIT 600, so it doesn't add change output.
+            # but the change amount is less than dust threshold 546, so it doesn't add change output.
             expect(subject.outputs.size).to eq(1)
             expect(subject.outputs[0].value).to eq(600)
           end

--- a/spec/glueby/internal/contract_builder/auto_fulfill_inputs_spec.rb
+++ b/spec/glueby/internal/contract_builder/auto_fulfill_inputs_spec.rb
@@ -26,6 +26,22 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
 
     subject { instance.build }
 
+    RSpec::Matchers.define :has_unique_inputs do
+      match do |tx|
+        tx.inputs.map { |i| i.out_point.txid + i.out_point.index.to_s }.uniq.size == tx.inputs.size
+      end
+
+      failure_message do |actual|
+        'expected that the tx has unique inputs but it has duplicated ' \
+        "inputs: #{actual.inputs.map { |i| i.out_point.to_payload.bth }}"
+      end
+
+      failure_message_when_negated do |actual|
+        'expected that the tx has duplicate inputs but it has unique ' \
+        "inputs: #{actual.inputs.map { |i| i.out_point.to_payload.bth }}"
+      end
+    end
+
     shared_examples 'it has enough inputs' do
       context 'fee is 0' do
         let(:fee_estimator) { Glueby::Contract::FeeEstimator::Fixed.new(fixed_fee: 0) }
@@ -38,6 +54,7 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
           it 'fulfill inputs from sender\'s wallet' do
             expect { subject }.not_to raise_error
             expect(subject.inputs.size).to eq(3)
+            expect(subject).to has_unique_inputs
           end
         end
 
@@ -49,6 +66,7 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
           it 'fulfill inputs from sender\'s wallet' do
             expect { subject }.not_to raise_error
             expect(subject.inputs.size).to eq(2)
+            expect(subject).to has_unique_inputs
           end
         end
 
@@ -61,6 +79,7 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
           it 'fulfill inputs from sender\'s wallet' do
             expect { subject }.not_to raise_error
             expect(subject.inputs.size).to eq(2)
+            expect(subject).to has_unique_inputs
           end
         end
 
@@ -72,6 +91,7 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
           it 'fulfill inputs from sender\'s wallet' do
             expect { subject }.not_to raise_error
             expect(subject.inputs.size).to eq(3)
+            expect(subject).to has_unique_inputs
           end
         end
       end
@@ -87,6 +107,7 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
           it 'fulfill inputs from sender\'s wallet' do
             expect { subject }.not_to raise_error
             expect(subject.inputs.size).to eq(4)
+            expect(subject).to has_unique_inputs
           end
         end
 
@@ -98,6 +119,7 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
           it 'fulfill inputs from sender\'s wallet' do
             expect { subject }.not_to raise_error
             expect(subject.inputs.size).to eq(3)
+            expect(subject).to has_unique_inputs
           end
         end
 
@@ -110,6 +132,7 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
           it 'fulfill inputs from sender\'s wallet' do
             expect { subject }.not_to raise_error
             expect(subject.inputs.size).to eq(3)
+            expect(subject).to has_unique_inputs
           end
         end
 
@@ -121,6 +144,7 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
           it 'fulfill inputs from sender\'s wallet' do
             expect { subject }.not_to raise_error
             expect(subject.inputs.size).to eq(4)
+            expect(subject).to has_unique_inputs
           end
         end
       end
@@ -129,8 +153,8 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
     context 'UtxoProvider is disabled' do
       before do
         # Here should funds UTXOs from sender's wallet
-        fund_to_wallet(sender_wallet)
-        fund_to_wallet(sender_wallet, color_id: valid_reissuable_color_id)
+        fund_to_wallet(sender_wallet, count: 4)
+        fund_to_wallet(sender_wallet, color_id: valid_reissuable_color_id, count: 4)
       end
       it_behaves_like 'it has enough inputs'
     end
@@ -140,8 +164,8 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
         Glueby.configuration.enable_utxo_provider!
 
         # Here should funds tapyrus UTXOs from UtxoProvider and colored coins UTXOs from sender's wallet
-        fund_to_wallet(Glueby::UtxoProvider.instance.wallet)
-        fund_to_wallet(sender_wallet, color_id: valid_reissuable_color_id)
+        fund_to_wallet(Glueby::UtxoProvider.instance.wallet, count: 4)
+        fund_to_wallet(sender_wallet, color_id: valid_reissuable_color_id, count: 4)
       end
 
       after do

--- a/spec/glueby/internal/contract_builder/auto_fulfill_inputs_spec.rb
+++ b/spec/glueby/internal/contract_builder/auto_fulfill_inputs_spec.rb
@@ -6,13 +6,11 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
       described_class.new(
         sender_wallet: sender_wallet,
         fee_estimator: fee_estimator,
-        use_auto_fee: use_auto_fee,
         use_auto_fulfill_inputs: true,
         use_unfinalized_utxo: use_unfinalized_utxo
       )
     end
     let(:sender_wallet) { Glueby::Internal::Wallet.create }
-    let(:use_auto_fee) { false }
     let(:use_unfinalized_utxo) { false }
 
     let(:valid_script_pubkey_hex) { '76a914ec88ce760de37265b11f48ee341248aab42615fb88ac' }

--- a/spec/glueby/internal/contract_builder_spec.rb
+++ b/spec/glueby/internal/contract_builder_spec.rb
@@ -5,14 +5,12 @@ RSpec.describe Glueby::Internal::ContractBuilder, active_record: true do
     described_class.new(
       sender_wallet: sender_wallet,
       fee_estimator: fee_estimator,
-      use_auto_fee: use_auto_fee,
       use_auto_fulfill_inputs: use_auto_fulfill_inputs,
       use_unfinalized_utxo: use_unfinalized_utxo
     )
   end
   let(:sender_wallet) { Glueby::Internal::Wallet.create }
   let(:fee_estimator) { Glueby::Contract::FeeEstimator::Fixed.new }
-  let(:use_auto_fee) { false }
   let(:use_auto_fulfill_inputs) { false }
   let(:use_unfinalized_utxo) { false }
 

--- a/spec/glueby/internal/wallet_spec.rb
+++ b/spec/glueby/internal/wallet_spec.rb
@@ -110,46 +110,46 @@ RSpec.describe 'Glueby::Internal::Wallet' do
           amount: 100_000_000,
           finalized: false
         },{
-        txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
-        script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
-        vout: 1,
-        amount: 100_000_000,
-        finalized: true
-      }, {
-        txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
-        script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
-        vout: 2,
-        amount: 50_000_000,
-        finalized: true
-      }, {
-        txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
-        vout: 0,
-        script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
-        color_id: 'c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893',
-        amount: 1,
-        finalized: true
-      }, {
-        txid: 'f14b29639483da7c8d17b7b7515da4ff78b91b4b89434e7988ab1bc21ab41377',
-        vout: 0,
-        script_pubkey: '21c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016bc76a914fc688c091d91789ccda7a27bd8d88be9ae4af58e88ac',
-        color_id: 'c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016',
-        amount: 100_000,
-        finalized: true
-      }, {
-        txid: '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2',
-        vout: 0,
-        script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
-        color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
-        amount: 100_000,
-        finalized: true
-      }, {
-        txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
-        vout: 2,
-        script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
-        color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
-        amount: 100_000,
-        finalized: true
-      }
+          txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
+          script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+          vout: 1,
+          amount: 100_000_000,
+          finalized: true
+        }, {
+          txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
+          script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+          vout: 2,
+          amount: 50_000_000,
+          finalized: true
+        }, {
+          txid: '864247cd4cae4b1f5bd3901be9f7a4ccba5bdea7db1d8bbd78b944da9cf39ef5',
+          vout: 0,
+          script_pubkey: '21c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893bc76a914bfeca7aed62174a7c60ebc63c7bd797bad46157a88ac',
+          color_id: 'c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893',
+          amount: 1,
+          finalized: true
+        }, {
+          txid: 'f14b29639483da7c8d17b7b7515da4ff78b91b4b89434e7988ab1bc21ab41377',
+          vout: 0,
+          script_pubkey: '21c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016bc76a914fc688c091d91789ccda7a27bd8d88be9ae4af58e88ac',
+          color_id: 'c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016',
+          amount: 100_000,
+          finalized: true
+        }, {
+          txid: '100c4dc65ea4af8abb9e345b3d4cdcc548bb5e1cdb1cb3042c840e147da72fa2',
+          vout: 0,
+          script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
+          amount: 100_000,
+          finalized: true
+        }, {
+          txid: 'a3f20bc94c8d77c35ba1770116d2b34375475a4194d15f76442636e9f77d50d9',
+          vout: 2,
+          script_pubkey: '21c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3bc76a9144f15d2203821d7ea719314126b79bd1e530fc97588ac',
+          color_id: 'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3',
+          amount: 100_000,
+          finalized: true
+        }
       ]
     end
     let(:finalized_unspents) { unspents.select{|i| i[:finalized]} }
@@ -159,10 +159,22 @@ RSpec.describe 'Glueby::Internal::Wallet' do
     include_context 'unspents'
     before { allow(internal_wallet).to receive(:list_unspent).and_return(finalized_unspents) }
 
-    subject { wallet.internal_wallet.collect_uncolored_outputs(amount, nil, only_finalized) }
+    subject do
+      wallet.internal_wallet.collect_uncolored_outputs(
+        amount,
+        nil,
+        only_finalized,
+        shuffle,
+        lock_utxos,
+        excludes
+      )
+    end
 
     let(:amount) { 150_000_000 }
     let(:only_finalized) { true }
+    let(:shuffle) { false }
+    let(:lock_utxos) { false }
+    let(:excludes) { [] }
     let(:wallet) { TestWallet.new(internal_wallet) }
     let(:internal_wallet) { TestInternalWallet.new }
 
@@ -196,12 +208,68 @@ RSpec.describe 'Glueby::Internal::Wallet' do
         expect(subject[1].size).to eq 3
       end
     end
+
+    context 'lock_utxos is true' do
+      let(:lock_utxos) { true }
+
+      it '#lock_unspent should be called for each UTXOs' do
+        allow(internal_wallet).to receive(:lock_unspent).with(unspents[1]).and_return(true)
+        allow(internal_wallet).to receive(:lock_unspent).with(unspents[2]).and_return(true)
+        subject
+        expect(internal_wallet).to have_received(:lock_unspent).with(unspents[1])
+        expect(internal_wallet).to have_received(:lock_unspent).with(unspents[2])
+      end
+    end
+
+    context 'excludes is specified' do
+      let(:excludes) { [unspents[1]] }
+      let(:amount) { 50_000_000 }
+
+      it 'returns except utxos that is includes the excludes' do
+        expect(subject[0]).to eq(50_000_000)
+        expect(subject[1].size).to eq(1)
+        expect(subject[1]).to eq([unspents[2]])
+      end
+    end
+
+    context 'it gets do .. end block' do
+      subject do
+        wallet.internal_wallet.collect_uncolored_outputs(
+          amount,
+          nil,
+          only_finalized,
+          shuffle,
+          lock_utxos,
+          excludes
+        ) do |utxo|
+          utxo[:amount] == 50_000_000
+        end
+      end
+
+      let(:amount) { 50_000_000 }
+
+      it 'returns a utxo that has 50_000_000 amount' do
+        expect(subject[0]).to eq(50_000_000)
+        expect(subject[1].size).to eq(1)
+        expect(subject[1]).to eq([unspents[2]])
+      end
+    end
   end
 
   describe '#collect_colored_outputs' do
     include_context 'unspents'
 
-    subject { wallet.internal_wallet.collect_colored_outputs(color_id, amount, label, only_finalized) }
+    subject do
+      wallet.internal_wallet.collect_colored_outputs(
+        color_id,
+        amount,
+        label,
+        only_finalized,
+        shuffle,
+        lock_utxos,
+        excludes
+      )
+    end
 
     let(:wallet) { TestWallet.new(internal_wallet) }
     let(:internal_wallet) { TestInternalWallet.new }
@@ -209,6 +277,9 @@ RSpec.describe 'Glueby::Internal::Wallet' do
     let(:amount) { 1_000 }
     let(:label) { nil }
     let(:only_finalized) { false }
+    let(:shuffle) { false }
+    let(:lock_utxos) { false }
+    let(:excludes) { [] }
 
     before { allow(internal_wallet).to receive(:list_unspent).and_return(unspents) }
 
@@ -246,6 +317,149 @@ RSpec.describe 'Glueby::Internal::Wallet' do
       it 'returns one output' do
         expect(subject[0]).to eq 200_000
         expect(subject[1].size).to eq 2
+      end
+    end
+
+    context 'lock_utxos is true' do
+      let(:lock_utxos) { true }
+      let(:amount) { 200_000 }
+
+      it '#lock_unspent should be called for each UTXOs' do
+        allow(internal_wallet).to receive(:lock_unspent).with(unspents[5]).and_return(true)
+        allow(internal_wallet).to receive(:lock_unspent).with(unspents[6]).and_return(true)
+        subject
+        expect(internal_wallet).to have_received(:lock_unspent).with(unspents[5])
+        expect(internal_wallet).to have_received(:lock_unspent).with(unspents[6])
+      end
+    end
+
+    context 'excludes is specified' do
+      let(:excludes) { [unspents[5]] }
+      let(:amount) { 100_000 }
+
+      it 'returns except utxos that is includes the excludes' do
+        expect(subject[0]).to eq(100_000)
+        expect(subject[1].size).to eq(1)
+        expect(subject[1]).to eq([unspents[6]])
+      end
+    end
+
+    context 'it gets do .. end block' do
+      subject do
+        wallet.internal_wallet.collect_colored_outputs(
+          color_id,
+          amount,
+          nil,
+          only_finalized,
+          shuffle,
+          lock_utxos,
+          excludes
+        ) do |utxo|
+          utxo[:vout] == 2
+        end
+      end
+
+      let(:amount) { 100_000 }
+
+      it 'returns a utxo that has 100_000 amount' do
+        expect(subject[0]).to eq(100_000)
+        expect(subject[1].size).to eq(1)
+        expect(subject[1]).to eq([unspents[6]])
+      end
+    end
+  end
+
+  describe '#fill_uncolored_inputs' do
+    subject do
+      internal_wallet.fill_uncolored_inputs(
+        tx,
+        target_amount: target_amount,
+        current_amount: current_amount,
+        fee_estimator: fee_estimator
+      )
+    end
+
+    let(:internal_wallet) { TestInternalWallet.new }
+
+    let(:tx) do
+      tx = Tapyrus::Tx.new
+      tx.outputs << Tapyrus::TxOut.new(value: 1_000, script_pubkey: Tapyrus::Script.to_p2pkh(Tapyrus::Key.generate.hash160))
+      tx
+    end
+    let(:target_amount) { 1_000 }
+    let(:current_amount) { 0 }
+
+    context 'use FeeEstimator::Auto' do
+      let(:fee_estimator) { Glueby::Contract::FeeEstimator::Auto.new }
+
+      context 'the tx has no inputs' do
+        let(:utxos) do
+          2.times.to_a.map{ |i| { txid: "33a87aa53268376862076180bad5aa0542373dfde22d4b4d62dd7016c16fd5a2", vout: i, amount: 1_000 } }
+        end
+
+        it 'adds inputs' do
+          allow(internal_wallet).to receive(:list_unspent).once.and_return(utxos)
+          tx, fee, current_amount, provided_utxos = subject
+          expect(tx.inputs.size).to eq(2)
+          expect(fee).to eq(360)
+          expect(current_amount).to eq(2_000)
+          expect(provided_utxos).to contain_exactly(*utxos)
+        end
+      end
+
+      context 'the tx already has enough TPC amount in inputs' do
+        let(:target_amount) { 1_000 }
+        let(:current_amount) { 2_000 }
+
+        before do
+          tx.inputs << Tapyrus::TxIn.new(out_point: Tapyrus::OutPoint.from_txid('33a87aa53268376862076180bad5aa0542373dfde22d4b4d62dd7016c16fd5a2', 0))
+        end
+
+        it 'doesn\'t add inputs' do
+          tx, fee, current_amount, provided_utxos = subject
+          expect(tx.inputs.size).to eq(1)
+          expect(fee).to eq(219)
+          expect(current_amount).to eq(2_000)
+          expect(provided_utxos).to be_empty
+        end
+      end
+
+      context 'the tx already has an TPC input' do
+        let(:target_amount) { 1_000 }
+        let(:current_amount) { 1_000 }
+
+        let(:utxos) do
+          [{ txid: "33a87aa53268376862076180bad5aa0542373dfde22d4b4d62dd7016c16fd5a2", vout: 0, amount: 1_000 }]
+        end
+
+        before do
+          tx.inputs << Tapyrus::TxIn.new(out_point: Tapyrus::OutPoint.from_txid('33a87aa53268376862076180bad5aa0542373dfde22d4b4d62dd7016c16fd5a2', 1))
+        end
+
+        it 'adds inputs' do
+          allow(internal_wallet).to receive(:list_unspent).once.and_return(utxos)
+          tx, fee, current_amount, provided_utxos = subject
+          expect(tx.inputs.size).to eq(2)
+          expect(fee).to eq(360)
+          expect(current_amount).to eq(2_000)
+          expect(provided_utxos).to contain_exactly(*utxos)
+        end
+      end
+
+      context 'by adding inputs, the fee will increase and insufficient' do
+        let(:target_amount) { 10_000 }
+        let(:utxos) do
+          12.times.to_a.map{ |i| { txid: "33a87aa53268376862076180bad5aa0542373dfde22d4b4d62dd7016c16fd5a2", vout: i, amount: 1_000 } }
+        end
+
+        it 'adds inputs' do
+          expect(internal_wallet).to receive(:list_unspent).twice.and_return(utxos)
+          tx, fee, current_amount, provided_utxos = subject
+          expect(tx.inputs.size).to eq(12)
+          expect(fee).to eq(1_770)
+          expect(current_amount).to eq(12_000)
+          expect(provided_utxos).to contain_exactly(*utxos)
+        end
       end
     end
   end

--- a/spec/support/contract_builder_test_support.rb
+++ b/spec/support/contract_builder_test_support.rb
@@ -1,6 +1,6 @@
 # Create fund to the wallet
 # @param [Glueby::Internal::Wallet] wallet
-def fund_to_wallet(wallet, color_id: Tapyrus::Color::ColorIdentifier.default)
+def fund_to_wallet(wallet, color_id: Tapyrus::Color::ColorIdentifier.default, count: 20)
   ar_wallet = Glueby::Internal::Wallet::AR::Wallet.find_by(wallet_id: wallet.id)
   ar_key = ar_wallet.keys.create!(purpose: :receive)
   txid = Tapyrus::sha256(wallet.id + color_id.to_hex).bth # dummy txid
@@ -11,7 +11,7 @@ def fund_to_wallet(wallet, color_id: Tapyrus::Color::ColorIdentifier.default)
                     valid_script_pubkey.add_color(color_id)
                   end
 
-  20.times do |i|
+  count.times do |i|
     Glueby::Internal::Wallet::AR::Utxo.create!(
       txid: txid,
       index: i,


### PR DESCRIPTION
This PR will fix below issue

When `#pay` of TPC is specified with both `use_auto_fee` and `use_auto_fulfill_inputs` enabled, both `auto_fee` and `auto_fulfill_inputs` try to set the UTXO of the TPC respectively, resulting in duplicate UTXOs may be set for both `auto_fee` and `auto_fulfill_inputs`.

`UtxoProvider` を利用している場合に、入力に重複するUTXOをセットする問題を修正しました。原因は UtxoProvider を利用している場合、auto_fulfill_inputs 機能でUtxoProviderのウォレットから入力をセットした後で、もう一度手数料のための UTXO をセットするために UtxoProviderのウォレットから UTXO を取得する際に、すでに使用した UTXO を取得することがあったことです。

これを修正するために以下の方針で修正を行いました。

* auto_fee 機能を廃止し、auto_fulfill_inputs 機能が有効の場合に auto_fee の機能も動作するようにして、仕様をシンプルにする。

この方針を実施するにあたって、オプションのパターンごとに同じ問題に対して違った方針で対応している箇所があったため挙動を統一しました。統一することで、auto_fulfill_inputs 機能に入力の自動保管機能を統合しやすくなります。

1. output を dust output と判定する処理を `TxOut#dust?` に統一する
     * DUST_LIMIT 定数と value を比較する処理がありましたが上に統一しました。
2. 手数料のための入力の追加で必要な手数料が増えた場合の対応を tx 作成者のウォレットからTPC を供給する設定の場合も有効にしました。
     * UtxoProvider を利用したときだけ有効な機能でしたが、tx 作成者のウォレットから TPC を拠出する場合も使えるようにしました。