### PR TITLE
The value which is less than 546 in Utxo should be invalid

### DIFF
--- a/lib/glueby/internal/wallet/active_record/utxo.rb
+++ b/lib/glueby/internal/wallet/active_record/utxo.rb
@@ -49,8 +49,9 @@ module Glueby
         private
 
           def check_dust_output
-            if !color_id && value < DUST_LIMIT
-              errors.add(:value, "is less than dust limit(#{DUST_LIMIT})")
+            output = Tapyrus::TxOut.new(value: value, script_pubkey: Tapyrus::Script.parse_from_payload(script_pubkey.htb))
+            if !color_id && output.dust?
+              errors.add(:value, "is less than dust limit(#{output.send(:dust_threshold)})")
             end
           end
         end

--- a/spec/glueby/contract/token_spec.rb
+++ b/spec/glueby/contract/token_spec.rb
@@ -545,7 +545,7 @@ RSpec.describe 'Glueby::Contract::Token', active_record: true do
         expect(internal_wallet).to receive(:broadcast).once do |tx|
           # 1 colored input(100_000 token), 1 uncolored inputs(1_000 tapyrus)
           # Fee is 455 tapyrus, so 545 tapyrus is change. But the change amount is less than 546, so the change
-          # output is not created. 550 tapyrus is also pay as fee.
+          # output is not created. 545 tapyrus is also pay as fee.
           expect(tx.inputs.count).to eq(2)
           expect(tx.outputs.count).to eq(1)
           expect(tx.outputs[0].value).to eq(50_000)

--- a/spec/glueby/internal/wallet/active_record/utxo_spec.rb
+++ b/spec/glueby/internal/wallet/active_record/utxo_spec.rb
@@ -80,16 +80,20 @@ RSpec.describe 'Glueby::Internal::Wallet::AR::Utxo', active_record: true  do
         )
       end
 
-      context 'output value is DUST_LIMIT' do
-        let(:value) { 600 }
+      context 'output value is dust threshold(546)' do
+        let(:value) { 546 }
 
         it { is_expected.to be_valid }
       end
 
-      context 'output is less than the DUST_LIMIT' do
-        let(:value) { 599 }
+      context 'output is less than dust threshold(546)' do
+        let(:value) { 545 }
 
         it { is_expected.to be_invalid }
+        it do
+          subject
+          expect(utxo.errors.full_messages).to eq ["Value is less than dust limit(546)"]
+        end
       end
     end
   end


### PR DESCRIPTION
The PR #174 causes the error when creating Utxo records with small values (< 546).

This PR solves this problem.

#174以前は、ContractBuilderでDUST_LIMIT(600)以下の値のアウトプットは生成していませんでしたが、#174で600未満(546以上)のアウトプットも生成される可能性が発生してます。その際に、Utxoレコードのバリデーションに失敗するため、Utxoでも600未満のアウトプットも許容するようにしています。
