### PR TITLE
Allow mysql adapter for Glueby::Wallet.configure(config)

### DIFF
--- a/lib/glueby/wallet.rb
+++ b/lib/glueby/wallet.rb
@@ -22,6 +22,9 @@ module Glueby
         when 'activerecord'
           Glueby::Internal::RPC.configure(config)
           Glueby::Internal::Wallet.wallet_adapter = Glueby::Internal::Wallet::ActiveRecordWalletAdapter.new
+        when 'mysql'
+          Glueby::Internal::RPC.configure(config)
+          Glueby::Internal::Wallet.wallet_adapter = Glueby::Internal::Wallet::MySQLWalletAdapter.new
         else
           raise 'Not implemented'
         end


### PR DESCRIPTION
This PR allows to set mysql wallet adapter using Glueby::Wallet.configure(config)