### PR TITLE
Add pagination functionality to Glueby::Wallet#balances

### DIFF
--- a/lib/glueby/constants.rb
+++ b/lib/glueby/constants.rb
@@ -1,4 +1,8 @@
 module Glueby
   # The minimum limit of transaction output value to avoid to be recognized as a dust output.
   DUST_LIMIT = 600
+
+  # Define pagination constants
+  DEFAULT_PER_PAGE = 25
+  MAX_PER_PAGE = 100
 end

--- a/lib/glueby/wallet.rb
+++ b/lib/glueby/wallet.rb
@@ -35,14 +35,16 @@ module Glueby
       @internal_wallet.id
     end
 
+    # @param [Boolean] only_finalized If true, return only finalized UTXOs
+    # @param [Integer] page The number of page. If it specified, return only the page. If not specified,
+    #                       return all color_ids.
+    # @param [Integer] per The number of UTXOs per page.
     # @return [HashMap] hash of balances which key is color_id or empty string, and value is amount
-    def balances(only_finalized = true)
-      utxos = @internal_wallet.list_unspent(only_finalized)
-      utxos.inject({}) do |balances, output|
-        key = output[:color_id] || ''
-        balances[key] ||= 0
-        balances[key] += output[:amount]
-        balances
+    def balances(only_finalized = true, page: nil, per: DEFAULT_PER_PAGE)
+      if page
+        internal_balances(only_finalized).sort[(page - 1) * per, per].to_h
+      else
+        internal_balances(only_finalized)
       end
     end
 
@@ -50,6 +52,16 @@ module Glueby
 
     def initialize(internal_wallet)
       @internal_wallet = internal_wallet
+    end
+
+    def internal_balances(only_finalized)
+      utxos = @internal_wallet.list_unspent(only_finalized)
+      utxos.inject({}) do |balances, output|
+        key = output[:color_id] || ''
+        balances[key] ||= 0
+        balances[key] += output[:amount]
+        balances
+      end
     end
   end
 end

--- a/spec/glueby/wallet_spec.rb
+++ b/spec/glueby/wallet_spec.rb
@@ -107,5 +107,59 @@ RSpec.describe 'Glueby::Wallet' do
 
       it { is_expected.to eq expected }
     end
+
+    context 'page parameter is specified' do
+      subject { wallet.balances(only_finalized, page: page) }
+
+      let(:only_finalized) { false }
+
+      context 'page is 1' do
+        let(:page) { 1 }
+        let(:expected) do
+          {
+            '' => 150_000_000,
+            'c14362a2e9fb5fa2da041d6a60d474cdc24218b2183855a22b7b20344f618c3ece' => 10_000,
+            'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3' => 200_000,
+            'c1de5b53145f480cf431c9697b197eb97da57dee816d068e572a20ebcc1b9cf6ea' => 100,
+            'c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016' => 100_000,
+            'c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893' => 1
+          }
+        end
+
+        it { is_expected.to eq expected }
+      end
+
+      context 'per is 4' do
+        subject { wallet.balances(only_finalized, page: page, per: per) }
+
+        let(:per) { 4 }
+
+        context 'page is 1' do
+          let(:page) { 1 }
+          let(:expected) do
+            {
+              '' => 150_000_000,
+              'c14362a2e9fb5fa2da041d6a60d474cdc24218b2183855a22b7b20344f618c3ece' => 10_000,
+              'c150ad685ec8638543b2356cb1071cf834fb1c84f5fa3a71699c3ed7167dfcdbb3' => 200_000,
+              'c1de5b53145f480cf431c9697b197eb97da57dee816d068e572a20ebcc1b9cf6ea' => 100
+            }
+          end
+
+          it { is_expected.to eq expected }
+        end
+
+        context 'page is 2' do
+          let(:page) { 2 }
+          let(:expected) do
+            {
+              'c2dbbebb191128de429084246fa3215f7ccc36d6abde62984eb5a42b1f2253a016' => 100_000,
+              'c3eb2b846463430b7be9962843a97ee522e3dc0994a0f5e2fc0aa82e20e67fe893' => 1
+            }
+          end
+
+          it { is_expected.to eq expected }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Glueby::Wallet#balances にページネーネーションのためにパラメーターを追加しました。

ページネーションを行っても、全件のUTXOを一旦メモリにロードするため性能上の問題があります。
本PRはこのままマージして、https://github.com/chaintope/tapyrus-api/issues/309 の完了後に別のPRを作成したいと考えています。

対応には以下の2案があります。 

* balanceのキャッシュデータをDBに作成する。
     * DBにcolor_id ごとに残高を持つためのデーブルを追加する
     * Token にキャッシュデータを管理するコードを追加する
* UTXOs テーブルに color_id カラムを追加して、color_id ごとに集計できるようにする
     * Utxosテーブルに color_id カラムを追加する
     * group by color_id で集計するSQLを使い残高を取得する
     * wallet adapter に balances メソッドを追加する。
