### PR TITLE
Fix simple timestamp records broken OP_RETURN data if the prefix or data of Simple#set_data contain a single hexadecimal digit

### DIFF
--- a/lib/glueby/contract/timestamp/tx_builder/simple.rb
+++ b/lib/glueby/contract/timestamp/tx_builder/simple.rb
@@ -22,10 +22,7 @@ module Glueby
             @prefix = prefix
             @data = data
 
-            contents = [prefix, data].map do |content|
-              content.unpack1('H*')
-            end
-
+            contents = [prefix, data].map(&:bth)
             @txb.data(*contents)
             self
           end

--- a/lib/glueby/contract/timestamp/tx_builder/simple.rb
+++ b/lib/glueby/contract/timestamp/tx_builder/simple.rb
@@ -23,7 +23,7 @@ module Glueby
             @data = data
 
             contents = [prefix, data].map do |content|
-              content.bytes.map { |i| i.to_s(16) }.join
+              content.unpack1('H*')
             end
 
             @txb.data(*contents)

--- a/spec/glueby/contract/timestamp/tx_builder/simple_spec.rb
+++ b/spec/glueby/contract/timestamp/tx_builder/simple_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'Glueby::Contract::TimestampTxBuilder::Simple', active_record: tr
     end
 
     context 'it gets a prefix that has a single hexadecimal digit' do
-      let(:prefix) { 'prefix' }
+      let(:prefix) { "prefix\x01" }
 
       it 'set correct OP_RETURN data' do
         tx = builder.build
@@ -103,7 +103,7 @@ RSpec.describe 'Glueby::Contract::TimestampTxBuilder::Simple', active_record: tr
     end
 
     context 'it gets a content that has a single hexadecimal digit' do
-      let(:content) { 'content' }
+      let(:content) { "content\x01" }
 
       it 'set correct OP_RETURN data' do
         tx = builder.build

--- a/spec/glueby/contract/timestamp/tx_builder/simple_spec.rb
+++ b/spec/glueby/contract/timestamp/tx_builder/simple_spec.rb
@@ -63,4 +63,82 @@ RSpec.describe 'Glueby::Contract::TimestampTxBuilder::Simple', active_record: tr
       end
     end
   end
+
+  describe '#build' do
+    let(:wallet) { TestWallet.new(internal_wallet) }
+    let(:internal_wallet) { TestInternalWallet.new }
+    let(:fee_estimator) { Glueby::Contract::FeeEstimator::Fixed.new }
+    let(:prefix) { 'prefix' }
+    let(:content) { 'content' }
+    let(:builder) do
+      Glueby::Contract::Timestamp::TxBuilder::Simple
+        .new(wallet, fee_estimator)
+        .set_inputs(nil)
+        .set_data(prefix, content)
+    end
+    let(:unspents) do
+      2.times.map do |i|
+        {
+          txid: '1d49c8038943d37c2723c9c7a1c4ea5c3738a9bad5827ddc41e144ba6aef36db',
+          script_pubkey: '76a914234113b860822e68f9715d1957af28b8f5117ee288ac',
+          vout: i,
+          amount: 50_000_000,
+          finalized: true
+        }
+      end
+    end
+
+    before do
+      allow(Glueby::Wallet).to receive(:load).and_return(wallet)
+      allow(internal_wallet).to receive(:list_unspent).and_return(unspents)
+    end
+
+    context 'it gets a prefix that has a single hexadecimal digit' do
+      let(:prefix) { 'prefix' }
+
+      it 'set correct OP_RETURN data' do
+        tx = builder.build
+        expect(tx.outputs.first.script_pubkey.op_return_data.bth).to eq('70726566697801636f6e74656e74')
+      end
+    end
+
+    context 'it gets a content that has a single hexadecimal digit' do
+      let(:content) { 'content' }
+
+      it 'set correct OP_RETURN data' do
+        tx = builder.build
+        expect(tx.outputs.first.script_pubkey.op_return_data.bth).to eq('707265666978636f6e74656e7401')
+      end
+    end
+
+    context 'prefix and contents are hex string' do
+      let(:prefix) { '707265666978' }
+      let(:content) { 'ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73' }
+
+      it 'set correct OP_RETURN data' do
+        tx = builder.build
+        expect(tx.outputs.first.script_pubkey.op_return_data.bth).to eq('37303732363536363639373865643730303262343339653961633834356632323335376438323262616331343434373330666264623630313664336563393433323239376239656339663733')
+      end
+    end
+
+    context 'prefix and contents are bytes stream' do
+      let(:prefix) { '707265666978'.htb }
+      let(:content) { 'ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73'.htb }
+
+      it 'set correct OP_RETURN data' do
+        tx = builder.build
+        expect(tx.outputs.first.script_pubkey.op_return_data.bth).to eq('707265666978ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73')
+      end
+    end
+
+    context 'prefix and contents contain multi bytes characters' do
+      let(:prefix) { 'プレフィックス' }
+      let(:content) { 'コンテンツ' }
+
+      it 'set correct OP_RETURN data' do
+        tx = builder.build
+        expect(tx.outputs.first.script_pubkey.op_return_data.bth).to eq('e38397e383ace38395e382a3e38383e382afe382b9e382b3e383b3e38386e383b3e38384')
+      end
+    end
+  end
 end


### PR DESCRIPTION
`Glueby::Contract::TimestampTxBuilder::Simple#set_data` の引数に HEX で１桁になる `\u0001` のような文字が含まれる場合に、２桁めの `0` が消えて桁がずれる問題を修正しました。