### PR TITLE
Make unlock UTXOs that is used as inputs in failure transactions

### DIFF
--- a/lib/glueby/active_record.rb
+++ b/lib/glueby/active_record.rb
@@ -4,5 +4,22 @@ require 'active_record'
 module Glueby
   module AR
     autoload :SystemInformation, 'glueby/active_record/system_information'
+
+    def transaction(isolation: nil)
+      options = { joinable: false, requires_new: true }
+
+      adapter_type = ActiveRecord::Base.connection.adapter_name.downcase
+
+      # SQLite3 does not support transaction isolation level READ COMMITTED.
+      if isolation == :read_committed && adapter_type == 'mysql2'
+        options[:isolation] = :read_committed
+      end
+
+      ActiveRecord::Base.transaction(**options) do
+        yield
+      end
+    end
+
+    module_function :transaction
   end
 end

--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -79,7 +79,6 @@ module Glueby
                          else
                            raise Glueby::Contract::Errors::UnsupportedTokenType
                          end
-
           [new(color_id: color_id), txs]
         end
 
@@ -354,7 +353,10 @@ module Glueby
           txb.pay(r[:address], r[:amount].to_i, color_id)
         end
 
-        tx = sender.internal_wallet.broadcast(txb.build)
+        tx = nil
+        ActiveRecord::Base.transaction(joinable: false, requires_new: true) do
+          tx = sender.internal_wallet.broadcast(txb.build)
+        end
         [color_id, tx]
       end
 

--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -134,7 +134,7 @@ module Glueby
           script_pubkey = funding_tx.outputs.first.script_pubkey
           color_id = Tapyrus::Color::ColorIdentifier.reissuable(script_pubkey)
 
-          ActiveRecord::Base.transaction(joinable: false, requires_new: true) do
+          Glueby::AR.transaction(isolation: :read_committed) do
             # Store the script_pubkey for reissue the token.
             Glueby::Contract::AR::ReissuableToken.create!(
               color_id: color_id.to_hex,
@@ -225,7 +225,7 @@ module Glueby
                     .build
           end
 
-          ActiveRecord::Base.transaction(joinable: false, requires_new: true) do
+          Glueby::AR.transaction(isolation: :read_committed) do
             if metadata
               p2c_utxo = txb.p2c_utxos.first
               Glueby::Contract::AR::TokenMetadata.create!(
@@ -354,7 +354,7 @@ module Glueby
         end
 
         tx = nil
-        ActiveRecord::Base.transaction(joinable: false, requires_new: true) do
+        Glueby::AR.transaction(isolation: :read_committed) do
           tx = sender.internal_wallet.broadcast(txb.build)
         end
         [color_id, tx]
@@ -385,7 +385,7 @@ module Glueby
                 .burn(amount, color_id)
                 .change_address(sender.internal_wallet.receive_address, color_id)
 
-        ActiveRecord::Base.transaction(joinable: false, requires_new: true) do
+        Glueby::AR.transaction(isolation: :read_committed) do
           tx = builder.build
           sender.internal_wallet.broadcast(tx)
         end

--- a/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
+++ b/lib/glueby/internal/wallet/active_record_wallet_adapter.rb
@@ -120,7 +120,7 @@ module Glueby
         end
 
         def broadcast(wallet_id, tx, &block)
-          ::ActiveRecord::Base.transaction do
+          ::ActiveRecord::Base.transaction(joinable: false, requires_new: true) do
             AR::Utxo.destroy_for_inputs(tx)
             AR::Utxo.create_or_update_for_outputs(tx, status: :broadcasted)
             block.call(tx) if block

--- a/spec/functional/token_spec.rb
+++ b/spec/functional/token_spec.rb
@@ -1,98 +1,170 @@
-RSpec.describe 'Token Contract', functional: true do
-  context 'use activerecord wallet adapter', active_record: true do
+RSpec.describe 'Token Contract', functional: true, mysql: true do
+  context 'bear fees by sender' do
+    let(:fee) { 10_000 }
+    let(:sender) { Glueby::Wallet.create }
+    let(:receiver) { Glueby::Wallet.create }
+    let(:before_balance) { sender.balances(false)[''] }
+
     before do
-      Glueby.configuration.wallet_adapter = :activerecord
+      process_block(to_address: sender.internal_wallet.receive_address)
+      process_block(to_address: receiver.internal_wallet.receive_address)
+      before_balance
     end
 
-    after do
-      Glueby::Internal::Wallet.wallet_adapter = nil
-    end
+    shared_examples 'token contract works correctly bearing fees by sender' do
+      it 'reissunable token' do
+        expect(Glueby::Contract::AR::ReissuableToken.count).to eq(0)
 
-    context 'bear fees by sender' do
-      let(:fee) { 10_000 }
-      let(:sender) { Glueby::Wallet.create }
-      let(:receiver) { Glueby::Wallet.create }
-      let(:before_balance) { sender.balances(false)[''] }
+        token, _txs = Glueby::Contract::Token.issue!(
+          issuer: sender,
+          token_type: Tapyrus::Color::TokenTypes::REISSUABLE,
+          amount: 10_000,
+          fee_estimator: fee_estimator
+        )
+        process_block
 
-      before do
-        process_block(to_address: sender.internal_wallet.receive_address)
-        process_block(to_address: receiver.internal_wallet.receive_address)
-        before_balance
-      end
+        if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+          expect(sender.balances(false)['']).to eq(before_balance - fee * 2)
+        end
 
-      shared_examples 'token contract works correctly bearing fees by sender' do
-        it 'reissunable token' do
-          expect(Glueby::Contract::AR::ReissuableToken.count).to eq(0)
+        expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
+        expect(Glueby::Contract::AR::ReissuableToken.count).to eq(1)
 
-          token, _txs = Glueby::Contract::Token.issue!(
+        token.transfer!(
+          sender: sender,
+          receiver_address: receiver.internal_wallet.receive_address,
+          amount: 5_000,
+          fee_estimator: fee_estimator
+        )
+        process_block
+
+        if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+          expect(sender.balances(false)['']).to eq(before_balance - fee * 3)
+        end
+
+        expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
+        expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
+
+        token.reissue!(issuer: sender, amount: 5_000, fee_estimator: fee_estimator)
+        process_block
+
+        if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+          expect(sender.balances(false)['']).to eq(before_balance - fee * 5)
+        end
+        expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
+
+        token.burn!(sender: sender, amount: 10_000, fee_estimator: fee_estimator)
+        process_block
+
+        if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+          expect(sender.balances(false)['']).to eq(before_balance - fee * 6)
+        end
+        expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+
+        # If the sending to Tapyrus Core is failure, Glueby::Contract::AR::ReissuableToken should not be created.
+        TapyrusCoreContainer.stop
+        begin
+          Glueby::Contract::Token.issue!(
             issuer: sender,
             token_type: Tapyrus::Color::TokenTypes::REISSUABLE,
             amount: 10_000,
             fee_estimator: fee_estimator
           )
-          process_block
+        rescue Errno::ECONNREFUSED
+          # Ignored
+        end
+        expect(Glueby::Contract::AR::ReissuableToken.count).to eq(1)
+      end
 
-          if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
-            expect(sender.balances(false)['']).to eq(before_balance - fee * 2)
-          end
+      it 'non-reissunable token' do
+        token, _txs = Glueby::Contract::Token.issue!(
+          issuer: sender,
+          token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE,
+          amount: 10_000,
+          fee_estimator: fee_estimator
+        )
+        process_block
 
-          expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
-          expect(Glueby::Contract::AR::ReissuableToken.count).to eq(1)
+        if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+          expect(sender.balances(false)['']).to eq(before_balance - fee * 1)
+        end
+        expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
 
-          token.transfer!(
-            sender: sender,
-            receiver_address: receiver.internal_wallet.receive_address,
-            amount: 5_000,
-            fee_estimator: fee_estimator
-          )
-          process_block
+        token.transfer!(
+          sender: sender,
+          receiver_address: receiver.internal_wallet.receive_address,
+          amount: 5_000,
+          fee_estimator: fee_estimator
+        )
+        process_block
 
-          if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
-            expect(sender.balances(false)['']).to eq(before_balance - fee * 3)
-          end
+        if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+          expect(sender.balances(false)['']).to eq(before_balance - fee * 2)
+        end
+        expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
+        expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
 
-          expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
-          expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
+        token.burn!(sender: sender, amount: 5_000, fee_estimator: fee_estimator)
+        process_block
 
-          token.reissue!(issuer: sender, amount: 5_000, fee_estimator: fee_estimator)
-          process_block
+        if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+          expect(sender.balances(false)['']).to eq(before_balance - fee * 3)
+        end
+        expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+      end
 
-          if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
-            expect(sender.balances(false)['']).to eq(before_balance - fee * 5)
-          end
-          expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
+      it 'NFT token' do
+        token, _txs = Glueby::Contract::Token.issue!(
+          issuer: sender,
+          token_type: Tapyrus::Color::TokenTypes::NFT,
+          fee_estimator: fee_estimator
+        )
+        process_block
 
-          token.burn!(sender: sender, amount: 10_000, fee_estimator: fee_estimator)
-          process_block
+        if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+          expect(sender.balances(false)['']).to eq(before_balance - fee * 1)
+        end
+        expect(sender.balances(false)[token.color_id.to_hex]).to eq(1)
 
-          if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
-            expect(sender.balances(false)['']).to eq(before_balance - fee * 6)
-          end
-          expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+        token.transfer!(
+          sender: sender,
+          receiver_address: receiver.internal_wallet.receive_address,
+          fee_estimator: fee_estimator
+        )
+        process_block
 
-          # If the sending to Tapyrus Core is failure, Glueby::Contract::AR::ReissuableToken should not be created.
-          TapyrusCoreContainer.stop
-          begin
-            Glueby::Contract::Token.issue!(
-              issuer: sender,
-              token_type: Tapyrus::Color::TokenTypes::REISSUABLE,
-              amount: 10_000,
-              fee_estimator: fee_estimator
-            )
-          rescue Errno::ECONNREFUSED
-            # Ignored
-          end
-          expect(Glueby::Contract::AR::ReissuableToken.count).to eq(1)
+        if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+          expect(sender.balances(false)['']).to eq(before_balance - fee * 2)
+        end
+        expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+        expect(receiver.balances(false)[token.color_id.to_hex]).to eq 1
+
+        receiver_before_balance = receiver.balances(false)['']
+
+        token.burn!(sender: receiver, amount: 1, fee_estimator: fee_estimator)
+        process_block
+
+        if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
+          expect(receiver.balances(false)['']).to eq(receiver_before_balance - fee)
         end
 
-        it 'non-reissunable token' do
+        expect(receiver.balances(false)[token.color_id.to_hex]).to be_nil
+      end
+
+      context 'transfer unconfirmed token' do
+        before do
+          Glueby::AR::SystemInformation.create(
+            info_key: 'use_only_finalized_utxo',
+            info_value: '0'
+          )
+        end
+        it do
           token, _txs = Glueby::Contract::Token.issue!(
             issuer: sender,
             token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE,
             amount: 10_000,
             fee_estimator: fee_estimator
           )
-          process_block
 
           if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
             expect(sender.balances(false)['']).to eq(before_balance - fee * 1)
@@ -105,7 +177,6 @@ RSpec.describe 'Token Contract', functional: true do
             amount: 5_000,
             fee_estimator: fee_estimator
           )
-          process_block
 
           if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
             expect(sender.balances(false)['']).to eq(before_balance - fee * 2)
@@ -114,378 +185,297 @@ RSpec.describe 'Token Contract', functional: true do
           expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
 
           token.burn!(sender: sender, amount: 5_000, fee_estimator: fee_estimator)
-          process_block
 
           if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
             expect(sender.balances(false)['']).to eq(before_balance - fee * 3)
           end
           expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
         end
-
-        it 'NFT token' do
-          token, _txs = Glueby::Contract::Token.issue!(
-            issuer: sender,
-            token_type: Tapyrus::Color::TokenTypes::NFT,
-            fee_estimator: fee_estimator
-          )
-          process_block
-
-          if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
-            expect(sender.balances(false)['']).to eq(before_balance - fee * 1)
-          end
-          expect(sender.balances(false)[token.color_id.to_hex]).to eq(1)
-
-          token.transfer!(
-            sender: sender,
-            receiver_address: receiver.internal_wallet.receive_address,
-            fee_estimator: fee_estimator
-          )
-          process_block
-
-          if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
-            expect(sender.balances(false)['']).to eq(before_balance - fee * 2)
-          end
-          expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
-          expect(receiver.balances(false)[token.color_id.to_hex]).to eq 1
-
-          receiver_before_balance = receiver.balances(false)['']
-
-          token.burn!(sender: receiver, amount: 1, fee_estimator: fee_estimator)
-          process_block
-
-          if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
-            expect(receiver.balances(false)['']).to eq(receiver_before_balance - fee)
-          end
-
-          expect(receiver.balances(false)[token.color_id.to_hex]).to be_nil
-        end
-
-        context 'transfer unconfirmed token' do
-          before do
-            Glueby::AR::SystemInformation.create(
-              info_key: 'use_only_finalized_utxo',
-              info_value: '0'
-            )
-          end
-          it do
-            token, _txs = Glueby::Contract::Token.issue!(
-              issuer: sender,
-              token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE,
-              amount: 10_000,
-              fee_estimator: fee_estimator
-            )
-
-            if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
-              expect(sender.balances(false)['']).to eq(before_balance - fee * 1)
-            end
-            expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
-
-            token.transfer!(
-              sender: sender,
-              receiver_address: receiver.internal_wallet.receive_address,
-              amount: 5_000,
-              fee_estimator: fee_estimator
-            )
-
-            if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
-              expect(sender.balances(false)['']).to eq(before_balance - fee * 2)
-            end
-            expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
-            expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
-
-            token.burn!(sender: sender, amount: 5_000, fee_estimator: fee_estimator)
-
-            if fee_estimator.is_a?(Glueby::Contract::FeeEstimator::Fixed)
-              expect(sender.balances(false)['']).to eq(before_balance - fee * 3)
-            end
-            expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
-          end
-        end
-      end
-
-      context 'fee estimator is Fixed' do
-        it_behaves_like 'token contract works correctly bearing fees by sender' do
-          let(:fee_estimator) { Glueby::Contract::FeeEstimator::Fixed.new(fixed_fee: fee) }
-        end
-      end
-
-      context 'fee estimator is Auto' do
-        it_behaves_like 'token contract works correctly bearing fees by sender' do
-          let(:fee_estimator) { Glueby::Contract::FeeEstimator::Auto.new }
-        end
       end
     end
 
-    context 'bear fees by FeeProvider' do
-      include_context 'setup fee provider'
-
-      let(:fee) { 10_000 }
-      let(:fee_estimator) { Glueby::Contract::FeeEstimator::Fixed.new(fixed_fee: fee) }
-      let(:sender) { Glueby::Wallet.create }
-      let(:receiver) { Glueby::Wallet.create }
-      let(:before_balance) { sender.balances(false)[''] }
-      let(:receiver_before_balance) { receiver.balances(false)[''] }
-
-      before do
-        process_block(to_address: sender.internal_wallet.receive_address)
-        process_block(to_address: receiver.internal_wallet.receive_address)
-        before_balance
-        receiver_before_balance
-      end
-
-      it 'reissunable token' do
-        token, _txs = Glueby::Contract::Token.issue!(
-          issuer: sender, token_type: Tapyrus::Color::TokenTypes::REISSUABLE, amount: 10_000)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance)
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
-
-        token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: 5_000)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance)
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
-        expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
-
-        token.reissue!(issuer: sender, amount: 5_000)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance)
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
-
-        token.burn!(sender: sender, amount: 10_000)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance)
-        expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
-      end
-
-      it 'non-reissunable token' do
-        token, _txs = Glueby::Contract::Token.issue!(
-          issuer: sender, token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE, amount: 10_000)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance)
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
-
-        token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: 5_000)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance)
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
-        expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
-
-        token.burn!(sender: sender, amount: 5_000)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance)
-        expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
-      end
-
-      it 'NFT token' do
-        token, _txs = Glueby::Contract::Token.issue!(issuer: sender, token_type: Tapyrus::Color::TokenTypes::NFT)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance)
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(1)
-
-        token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address)
-        process_block
-
-        expect(sender.balances(false)['']).to eq(before_balance)
-        expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
-        expect(receiver.balances(false)[token.color_id.to_hex]).to eq 1
-
-        token.burn!(sender: receiver, amount: 1)
-        process_block
-
-        expect(receiver.balances(false)['']).to eq(receiver_before_balance)
-        expect(receiver.balances(false)[token.color_id.to_hex]).to be_nil
+    context 'fee estimator is Fixed' do
+      it_behaves_like 'token contract works correctly bearing fees by sender' do
+        let(:fee_estimator) { Glueby::Contract::FeeEstimator::Fixed.new(fixed_fee: fee) }
       end
     end
 
-    context 'UtxoProvider provides UTXOs' do
-      include_context 'setup utxo provider'
-
-      let(:sender) { Glueby::Wallet.create }
-      let(:receiver) { Glueby::Wallet.create }
-
-      it 'reissunable token' do
-        token, _txs = Glueby::Contract::Token.issue!(
-          issuer: sender, token_type: Tapyrus::Color::TokenTypes::REISSUABLE, amount: 10_000)
-        process_block
-
-        expect(sender.balances(false)['']).to be_nil
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
-
-        # Specify split option
-        # It allow to split up to 24. If it set over 24, it raises the min relay fee error.
-        # It uses Fixed fee strategy and the strategy estimate the fee to fixed amount but here it is insufficient to split to much outputs.
-        token2, _txs = Glueby::Contract::Token.issue!(
-          issuer: sender, token_type: Tapyrus::Color::TokenTypes::REISSUABLE, amount: 10_000, split: 24)
-        process_block
-
-        expect(sender.balances(false)['']).to be_nil
-        expect(sender.balances(false)[token2.color_id.to_hex]).to eq(10_000)
-
-        # Specify split option with FeeEstimator::Auto. It allow to split over 26.
-        token3, _txs = Glueby::Contract::Token.issue!(
-          issuer: sender, token_type: Tapyrus::Color::TokenTypes::REISSUABLE, amount: 10_000, split: 100,
-          fee_estimator: Glueby::Contract::FeeEstimator::Auto.new)
-        process_block
-
-        expect(sender.balances(false)['']).to be_nil
-        expect(sender.balances(false)[token3.color_id.to_hex]).to eq(10_000)
-
-        # Specify metadata option
-        token4, _txs = Glueby::Contract::Token.issue!(
-          issuer: sender, token_type: Tapyrus::Color::TokenTypes::REISSUABLE,
-          amount: 10_000,
-          fee_estimator: Glueby::Contract::FeeEstimator::Auto.new,
-          metadata: 'metadata'
-        )
-        process_block
-
-        expect(sender.balances(false)['']).to be_nil
-        expect(sender.balances(false)[token4.color_id.to_hex]).to eq(10_000)
-
-        token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: 5_000)
-        process_block
-
-        expect(sender.balances(false)['']).to be_nil
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
-        expect(receiver.balances(false)['']).to be_nil
-        expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
-
-        token.reissue!(issuer: sender, amount: 5_000)
-        process_block
-
-        token3.reissue!(issuer: sender, amount: 10_000, split: 100, fee_estimator: Glueby::Contract::FeeEstimator::Auto.new)
-        process_block
-
-        expect(sender.balances(false)['']).to be_nil
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
-
-        token.burn!(sender: sender, amount: 10_000)
-        process_block
-
-        expect(sender.balances(false)['']).to be_nil
-        expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
-
-        token4.reissue!(issuer: sender, amount: 10_000, fee_estimator: Glueby::Contract::FeeEstimator::Auto.new)
-        process_block
-
-        expect(sender.balances(false)['']).to be_nil
-        expect(sender.balances(false)[token4.color_id.to_hex]).to eq(20_000)
-      end
-
-      it 'non-reissunable token' do
-        token, _txs = Glueby::Contract::Token.issue!(
-          issuer: sender, token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE, amount: 10_000)
-        process_block
-
-        expect(sender.balances(false)['']).to be_nil
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
-
-        token2, _txs = Glueby::Contract::Token.issue!(
-          issuer: sender, token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE, amount: 10_000, split: 100,
-          fee_estimator: Glueby::Contract::FeeEstimator::Auto.new)
-        process_block
-
-        expect(sender.balances(false)['']).to be_nil
-        expect(sender.balances(false)[token2.color_id.to_hex]).to eq(10_000)
-        expect(sender.internal_wallet.list_unspent(false).select {|i| i[:color_id] == token2.color_id.to_hex}.size).to eq(100)
-
-        # Specify metadata option
-        token3, _txs = Glueby::Contract::Token.issue!(
-          issuer: sender, token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE,
-          amount: 10_000,
-          fee_estimator: Glueby::Contract::FeeEstimator::Auto.new,
-          metadata: 'metadata'
-        )
-        process_block
-        expect(sender.balances(false)['']).to be_nil
-        expect(sender.balances(false)[token3.color_id.to_hex]).to eq(10_000)
-
-        token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: 5_000)
-        process_block
-
-        expect(sender.balances(false)['']).to be_nil
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
-        expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
-
-        token.burn!(sender: sender, amount: 5_000)
-        process_block
-
-        expect(sender.balances(false)['']).to be_nil
-        expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
-      end
-
-      it 'NFT token' do
-        token, _txs = Glueby::Contract::Token.issue!(issuer: sender, token_type: Tapyrus::Color::TokenTypes::NFT)
-        process_block
-
-        expect(sender.balances(false)['']).to be_nil
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(1)
-
-        # Specify metadata option
-        token2, _txs = Glueby::Contract::Token.issue!(
-          issuer: sender, token_type: Tapyrus::Color::TokenTypes::NFT,
-          fee_estimator: Glueby::Contract::FeeEstimator::Auto.new,
-          metadata: 'metadata'
-        )
-        process_block
-        expect(sender.balances(false)['']).to be_nil
-        expect(sender.balances(false)[token2.color_id.to_hex]).to eq(1)
-
-        token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address)
-        process_block
-
-        expect(sender.balances(false)['']).to be_nil
-        expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
-        expect(receiver.balances(false)[token.color_id.to_hex]).to eq 1
-
-        token.burn!(sender: receiver, amount: 1)
-        process_block
-
-        expect(receiver.balances(false)['']).to be_nil
-        expect(receiver.balances(false)[token.color_id.to_hex]).to be_nil
-      end
-
-      it 'multiple transfer' do
-        token, _txs = Glueby::Contract::Token.issue!(
-          issuer: sender, token_type: Tapyrus::Color::TokenTypes::REISSUABLE, amount: 10_000)
-        process_block
-
-        expect(sender.balances(false)['']).to be_nil
-        expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
-
-        receivers = 100.times.map { { address: receiver.internal_wallet.receive_address, amount: 100 } }
-        token.multi_transfer!(sender: sender, receivers: receivers, fee_estimator: Glueby::Contract::FeeEstimator::Auto.new)
-
-        expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
-        expect(receiver.balances(false)[token.color_id.to_hex]).to eq(10_000)
-        expect(receiver.internal_wallet.list_unspent(false).select {|i| i[:color_id] == token.color_id.to_hex}.size).to eq(100)
-      end
-
-      it 'doesn\'t raise insufficient error in too much split number' do
-        expect do
-          Glueby::Contract::Token.issue!(
-            issuer: sender, token_type: Tapyrus::Color::TokenTypes::REISSUABLE, amount: 10_000, split: 25)
-        end.not_to raise_error
-        expect(sender.balances(false)['']).to be_nil
-
-        expect do
-          Glueby::Contract::Token.issue!(
-            issuer: sender, token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE, amount: 10_000, split: 25)
-        end.not_to raise_error
-        expect(sender.balances(false)['']).to be_nil
+    context 'fee estimator is Auto' do
+      it_behaves_like 'token contract works correctly bearing fees by sender' do
+        let(:fee_estimator) { Glueby::Contract::FeeEstimator::Auto.new }
       end
     end
   end
 
-  context 'use mysql', mysql: true do
+  context 'bear fees by FeeProvider' do
+    include_context 'setup fee provider'
+
+    let(:fee) { 10_000 }
+    let(:fee_estimator) { Glueby::Contract::FeeEstimator::Fixed.new(fixed_fee: fee) }
+    let(:sender) { Glueby::Wallet.create }
+    let(:receiver) { Glueby::Wallet.create }
+    let(:before_balance) { sender.balances(false)[''] }
+    let(:receiver_before_balance) { receiver.balances(false)[''] }
+
+    before do
+      process_block(to_address: sender.internal_wallet.receive_address)
+      process_block(to_address: receiver.internal_wallet.receive_address)
+      before_balance
+      receiver_before_balance
+    end
+
+    it 'reissunable token' do
+      token, _txs = Glueby::Contract::Token.issue!(
+        issuer: sender, token_type: Tapyrus::Color::TokenTypes::REISSUABLE, amount: 10_000)
+      process_block
+
+      expect(sender.balances(false)['']).to eq(before_balance)
+      expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
+
+      token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: 5_000)
+      process_block
+
+      expect(sender.balances(false)['']).to eq(before_balance)
+      expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
+      expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
+
+      token.reissue!(issuer: sender, amount: 5_000)
+      process_block
+
+      expect(sender.balances(false)['']).to eq(before_balance)
+      expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
+
+      token.burn!(sender: sender, amount: 10_000)
+      process_block
+
+      expect(sender.balances(false)['']).to eq(before_balance)
+      expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+    end
+
+    it 'non-reissunable token' do
+      token, _txs = Glueby::Contract::Token.issue!(
+        issuer: sender, token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE, amount: 10_000)
+      process_block
+
+      expect(sender.balances(false)['']).to eq(before_balance)
+      expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
+
+      token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: 5_000)
+      process_block
+
+      expect(sender.balances(false)['']).to eq(before_balance)
+      expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
+      expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
+
+      token.burn!(sender: sender, amount: 5_000)
+      process_block
+
+      expect(sender.balances(false)['']).to eq(before_balance)
+      expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+    end
+
+    it 'NFT token' do
+      token, _txs = Glueby::Contract::Token.issue!(issuer: sender, token_type: Tapyrus::Color::TokenTypes::NFT)
+      process_block
+
+      expect(sender.balances(false)['']).to eq(before_balance)
+      expect(sender.balances(false)[token.color_id.to_hex]).to eq(1)
+
+      token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address)
+      process_block
+
+      expect(sender.balances(false)['']).to eq(before_balance)
+      expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+      expect(receiver.balances(false)[token.color_id.to_hex]).to eq 1
+
+      token.burn!(sender: receiver, amount: 1)
+      process_block
+
+      expect(receiver.balances(false)['']).to eq(receiver_before_balance)
+      expect(receiver.balances(false)[token.color_id.to_hex]).to be_nil
+    end
+  end
+
+  context 'UtxoProvider provides UTXOs' do
+    include_context 'setup utxo provider'
+
+    let(:sender) { Glueby::Wallet.create }
+    let(:receiver) { Glueby::Wallet.create }
+
+    it 'reissunable token' do
+      token, _txs = Glueby::Contract::Token.issue!(
+        issuer: sender, token_type: Tapyrus::Color::TokenTypes::REISSUABLE, amount: 10_000)
+      process_block
+
+      expect(sender.balances(false)['']).to be_nil
+      expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
+
+      # Specify split option
+      # It allow to split up to 24. If it set over 24, it raises the min relay fee error.
+      # It uses Fixed fee strategy and the strategy estimate the fee to fixed amount but here it is insufficient to split to much outputs.
+      token2, _txs = Glueby::Contract::Token.issue!(
+        issuer: sender, token_type: Tapyrus::Color::TokenTypes::REISSUABLE, amount: 10_000, split: 24)
+      process_block
+
+      expect(sender.balances(false)['']).to be_nil
+      expect(sender.balances(false)[token2.color_id.to_hex]).to eq(10_000)
+
+      # Specify split option with FeeEstimator::Auto. It allow to split over 26.
+      token3, _txs = Glueby::Contract::Token.issue!(
+        issuer: sender, token_type: Tapyrus::Color::TokenTypes::REISSUABLE, amount: 10_000, split: 100,
+        fee_estimator: Glueby::Contract::FeeEstimator::Auto.new)
+      process_block
+
+      expect(sender.balances(false)['']).to be_nil
+      expect(sender.balances(false)[token3.color_id.to_hex]).to eq(10_000)
+
+      # Specify metadata option
+      token4, _txs = Glueby::Contract::Token.issue!(
+        issuer: sender, token_type: Tapyrus::Color::TokenTypes::REISSUABLE,
+        amount: 10_000,
+        fee_estimator: Glueby::Contract::FeeEstimator::Auto.new,
+        metadata: 'metadata'
+      )
+      process_block
+
+      expect(sender.balances(false)['']).to be_nil
+      expect(sender.balances(false)[token4.color_id.to_hex]).to eq(10_000)
+
+      token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: 5_000)
+      process_block
+
+      expect(sender.balances(false)['']).to be_nil
+      expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
+      expect(receiver.balances(false)['']).to be_nil
+      expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
+
+      token.reissue!(issuer: sender, amount: 5_000)
+      process_block
+
+      token3.reissue!(issuer: sender, amount: 10_000, split: 100, fee_estimator: Glueby::Contract::FeeEstimator::Auto.new)
+      process_block
+
+      expect(sender.balances(false)['']).to be_nil
+      expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
+
+      token.burn!(sender: sender, amount: 10_000)
+      process_block
+
+      expect(sender.balances(false)['']).to be_nil
+      expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+
+      token4.reissue!(issuer: sender, amount: 10_000, fee_estimator: Glueby::Contract::FeeEstimator::Auto.new)
+      process_block
+
+      expect(sender.balances(false)['']).to be_nil
+      expect(sender.balances(false)[token4.color_id.to_hex]).to eq(20_000)
+    end
+
+    it 'non-reissunable token' do
+      token, _txs = Glueby::Contract::Token.issue!(
+        issuer: sender, token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE, amount: 10_000)
+      process_block
+
+      expect(sender.balances(false)['']).to be_nil
+      expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
+
+      token2, _txs = Glueby::Contract::Token.issue!(
+        issuer: sender, token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE, amount: 10_000, split: 100,
+        fee_estimator: Glueby::Contract::FeeEstimator::Auto.new)
+      process_block
+
+      expect(sender.balances(false)['']).to be_nil
+      expect(sender.balances(false)[token2.color_id.to_hex]).to eq(10_000)
+      expect(sender.internal_wallet.list_unspent(false).select {|i| i[:color_id] == token2.color_id.to_hex}.size).to eq(100)
+
+      # Specify metadata option
+      token3, _txs = Glueby::Contract::Token.issue!(
+        issuer: sender, token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE,
+        amount: 10_000,
+        fee_estimator: Glueby::Contract::FeeEstimator::Auto.new,
+        metadata: 'metadata'
+      )
+      process_block
+      expect(sender.balances(false)['']).to be_nil
+      expect(sender.balances(false)[token3.color_id.to_hex]).to eq(10_000)
+
+      token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address, amount: 5_000)
+      process_block
+
+      expect(sender.balances(false)['']).to be_nil
+      expect(sender.balances(false)[token.color_id.to_hex]).to eq(5_000)
+      expect(receiver.balances(false)[token.color_id.to_hex]).to eq(5_000)
+
+      token.burn!(sender: sender, amount: 5_000)
+      process_block
+
+      expect(sender.balances(false)['']).to be_nil
+      expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+    end
+
+    it 'NFT token' do
+      token, _txs = Glueby::Contract::Token.issue!(issuer: sender, token_type: Tapyrus::Color::TokenTypes::NFT)
+      process_block
+
+      expect(sender.balances(false)['']).to be_nil
+      expect(sender.balances(false)[token.color_id.to_hex]).to eq(1)
+
+      # Specify metadata option
+      token2, _txs = Glueby::Contract::Token.issue!(
+        issuer: sender, token_type: Tapyrus::Color::TokenTypes::NFT,
+        fee_estimator: Glueby::Contract::FeeEstimator::Auto.new,
+        metadata: 'metadata'
+      )
+      process_block
+      expect(sender.balances(false)['']).to be_nil
+      expect(sender.balances(false)[token2.color_id.to_hex]).to eq(1)
+
+      token.transfer!(sender: sender, receiver_address: receiver.internal_wallet.receive_address)
+      process_block
+
+      expect(sender.balances(false)['']).to be_nil
+      expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+      expect(receiver.balances(false)[token.color_id.to_hex]).to eq 1
+
+      token.burn!(sender: receiver, amount: 1)
+      process_block
+
+      expect(receiver.balances(false)['']).to be_nil
+      expect(receiver.balances(false)[token.color_id.to_hex]).to be_nil
+    end
+
+    it 'multiple transfer' do
+      token, _txs = Glueby::Contract::Token.issue!(
+        issuer: sender, token_type: Tapyrus::Color::TokenTypes::REISSUABLE, amount: 10_000)
+      process_block
+
+      expect(sender.balances(false)['']).to be_nil
+      expect(sender.balances(false)[token.color_id.to_hex]).to eq(10_000)
+
+      receivers = 100.times.map { { address: receiver.internal_wallet.receive_address, amount: 100 } }
+      token.multi_transfer!(sender: sender, receivers: receivers, fee_estimator: Glueby::Contract::FeeEstimator::Auto.new)
+
+      expect(sender.balances(false)[token.color_id.to_hex]).to be_nil
+      expect(receiver.balances(false)[token.color_id.to_hex]).to eq(10_000)
+      expect(receiver.internal_wallet.list_unspent(false).select {|i| i[:color_id] == token.color_id.to_hex}.size).to eq(100)
+    end
+
+    it 'doesn\'t raise insufficient error in too much split number' do
+      expect do
+        Glueby::Contract::Token.issue!(
+          issuer: sender, token_type: Tapyrus::Color::TokenTypes::REISSUABLE, amount: 10_000, split: 25)
+      end.not_to raise_error
+      expect(sender.balances(false)['']).to be_nil
+
+      expect do
+        Glueby::Contract::Token.issue!(
+          issuer: sender, token_type: Tapyrus::Color::TokenTypes::NON_REISSUABLE, amount: 10_000, split: 25)
+      end.not_to raise_error
+      expect(sender.balances(false)['']).to be_nil
+    end
+  end
+
+  context 'multi threading' do
     include_context 'setup utxo provider'
     let(:utxo_pool_size) { 40 }
     let(:utxo_provider) { Glueby::UtxoProvider.new }

--- a/spec/functional/token_spec.rb
+++ b/spec/functional/token_spec.rb
@@ -499,13 +499,9 @@ RSpec.describe 'Token Contract', functional: true do
 
     shared_examples 'issuing token works correctly' do
       def issue_on_multi_thread(count)
-        threads = count.times.map do |i|
-          Thread.new do
-            issue
-          end
+        on_multi_thread(count) do
+          issue
         end
-        # Each value is Token object
-        threads.map { |t| t.value }
       end
 
       def issue
@@ -564,10 +560,9 @@ RSpec.describe 'Token Contract', functional: true do
       end
 
       def transfer_on_multi_thread(count)
-        threads = count.times.map do
-          Thread.new { transfer(issue_amount / count) }
+        on_multi_thread(count) do
+          transfer(issue_amount / count)
         end
-        threads.map { |t| t.value }
       end
 
       def transfer(amount)

--- a/spec/functional/token_spec.rb
+++ b/spec/functional/token_spec.rb
@@ -498,16 +498,20 @@ RSpec.describe 'Token Contract', functional: true do
     def issue_on_multi_thread(count)
       threads = count.times.map do |i|
         Thread.new do
-          token, _txs = Glueby::Contract::Token.issue!(
-            issuer: sender,
-            token_type: Tapyrus::Color::TokenTypes::REISSUABLE,
-            amount: 10_000
-          )
-          token
+          issue
         end
       end
       # Each value is Token object
       threads.map { |t| t.value }
+    end
+
+    def issue
+      token, _txs = Glueby::Contract::Token.issue!(
+        issuer: sender,
+        token_type: Tapyrus::Color::TokenTypes::REISSUABLE,
+        amount: 10_000
+      )
+      token
     end
 
     it 'broadcast transactions with no error on multi thread' do
@@ -523,31 +527,52 @@ RSpec.describe 'Token Contract', functional: true do
       expect(utxo_provider.current_utxo_pool_size).to eq utxo_pool_size - count
     end
 
+    context 'broadcasting funding tx is failure' do
+      let(:count) { 1 }
+      let(:rpc) { double('mock') }
+
+      before do
+        allow(Glueby::Internal::RPC).to receive(:client).and_return(rpc)
+        allow(rpc).to receive(:sendrawtransaction).and_raise(Tapyrus::RPC::Error.new(
+          '500',
+          'Internal Server Error',
+          { 'code' => -25, 'message' => 'Missing inputs'}))
+      end
+
+      it 'unlock UTXOs that are used as inputs' do
+        expect { issue }.to raise_error(Tapyrus::RPC::Error)
+        expect(Glueby::Internal::Wallet::AR::Utxo.where('locked_at is not null').count).to eq 0
+      end
+    end
+
     context 'transferring token' do
       let(:issue_amount) { 100_000 }
-      let(:token) do
+      let!(:token) do
         token, _tx = Glueby::Contract::Token.issue!(
           issuer: sender,
           token_type: Tapyrus::Color::TokenTypes::REISSUABLE,
           split: count,
           amount: issue_amount
         )
+
+        Rake.application['glueby:utxo_provider:manage_utxo_pool'].execute
         process_block
         token
       end
       def transfer_on_multi_thread(count)
         threads = count.times.map do
-          Thread.new do
-            result = token.transfer!(
-              sender: sender,
-              receiver_address: receiver.internal_wallet.receive_address,
-              amount: issue_amount / count,
-              fee_estimator: Glueby::Contract::FeeEstimator::Auto.new
-            )
-            result
-          end
+          Thread.new { transfer(issue_amount / count) }
         end
         threads.map { |t| t.value }
+      end
+
+      def transfer(amount)
+        token.transfer!(
+          sender: sender,
+          receiver_address: receiver.internal_wallet.receive_address,
+          amount: amount,
+          fee_estimator: Glueby::Contract::FeeEstimator::Auto.new
+        )
       end
 
       it 'broadast transactions with no error on multi thread' do
@@ -557,7 +582,25 @@ RSpec.describe 'Token Contract', functional: true do
 
         expect(sender.balances(false)['']).to be_nil
         expect(receiver.balances(false)[token.color_id.to_hex]).to eq(issue_amount)
-        expect(utxo_provider.current_utxo_pool_size).to eq utxo_pool_size - (count + 1)
+        expect(utxo_provider.current_utxo_pool_size).to eq utxo_pool_size - count
+      end
+
+      context 'broadcasting is failure' do
+        let(:count) { 1 }
+        let(:rpc) { double('mock') }
+
+        before do
+          allow(Glueby::Internal::RPC).to receive(:client).and_return(rpc)
+          allow(rpc).to receive(:sendrawtransaction).and_raise(Tapyrus::RPC::Error.new(
+            '500',
+            'Internal Server Error',
+            { 'code' => -25, 'message' => 'Missing inputs'}))
+        end
+
+        it 'unlock UTXOs that are used as inputs' do
+          expect { transfer(issue_amount) }.to raise_error(Tapyrus::RPC::Error)
+          expect(Glueby::Internal::Wallet::AR::Utxo.where('locked_at is not null').count).to eq 0
+        end
       end
     end
   end

--- a/spec/glueby/contract/timestamp/active_record/timestamp_spec.rb
+++ b/spec/glueby/contract/timestamp/active_record/timestamp_spec.rb
@@ -443,7 +443,7 @@ RSpec.describe 'Glueby::Contract::AR::Timestamp', active_record: true do
       end
 
       it do
-        expect { subject }.to raise_error(Glueby::Contract::Errors::FailedToBroadcast, 'failed to broadcast (id=, reason=error message)')
+        expect { subject }.to raise_error(Glueby::Contract::Errors::FailedToBroadcast, 'failed to broadcast (id=1, reason=error message)')
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,8 @@ RSpec.configure do |config|
   config.before(:each) do |example|
     if example.metadata[:active_record]
       setup_database
+
+      ActiveRecord::Base.logger = Logger.new(STDOUT) if ENV['DEBUG']
     end
 
     if example.metadata[:functional]
@@ -35,6 +37,8 @@ RSpec.configure do |config|
         MySQLContainer.setup
         MySQLContainer.start
         setup_database(config: MySQLContainer.config)
+
+        ActiveRecord::Base.logger = Logger.new(STDOUT) if ENV['DEBUG']
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,6 +75,7 @@ require_relative 'support/mysql'
 require_relative 'support/setup_fee_provider'
 require_relative 'support/setup_utxo_provider'
 require_relative 'support/negated_matchers'
+require_relative 'support/multi_thread'
 
 def sqlite3_config
   { adapter: 'sqlite3', database: File.join(Dir.tmpdir, 'glueby-test-db') }

--- a/spec/support/multi_thread.rb
+++ b/spec/support/multi_thread.rb
@@ -1,0 +1,9 @@
+def on_multi_thread(count)
+  threads = count.times.map do |i|
+    Thread.new do
+      yield(i)
+    end
+  end
+  # Each value is Token object
+  threads.map { |t| t.value }
+end

--- a/spec/support/multi_thread.rb
+++ b/spec/support/multi_thread.rb
@@ -1,7 +1,16 @@
 def on_multi_thread(count)
+  if ENV['DEBUG']
+    ActiveRecord::Base.logger = Logger.new(STDOUT)
+    ActiveRecord::Base.logger.formatter = proc do |severity, datetime, progname, msg|
+      thread_number = sprintf("%02d", Thread.current[:thread_number] || 0)
+      "THREAD##{thread_number}, #{severity[0]}, [#{datetime.strftime('%Y-%m-%dT%H:%M:%S.%6N')} ##{Process.pid}] #{severity} -- : #{msg}\n"
+    end
+  end
+
   threads = count.times.map do |i|
-    Thread.new do
-      yield(i)
+    Thread.new(i) do |thread_number|
+      Thread.current[:thread_number] = thread_number
+      yield(thread_number)
     end
   end
   # Each value is Token object


### PR DESCRIPTION
resolves #182 

Tx のブロードキャストに失敗したときに、ロックした UTXO がロックしたままになる問題を修正しました。

以下の方針を定め、それに合わせて修正しています。また、Timestamp, Tracking でも同様の対応が必要と思われます。

1. #build と TX のブロードキャストは同一のトランザクションブロックに入れる。
2. 単体で funding TX の作成とブロードキャストをする #add_utxo_to! と #add_p2c_utxo_to! は 1. のトランザクションブロックに入れない。
3. TX のブロードキャスト処理は、トランザクションブロック内のDB操作の一番最後に記述する。
4. TX のブロードキャスト処理を含むDBトランザクションは、トランザクション分離レベルを READ COMMITTED にする。

ここでは、Tapyrus トランザクションは TX、データベースのトランザクションは DB トランザクションと記述して区別している。

## 1. #build と TX のブロードキャストは同一のトランザクションブロックに入れる。

use_auto_fulfill_inputs が有効であるとき、 `#build` 時に入力にセットする UTXO を収集しロックする。
このロック操作とブロードキャストを同一のDBトランザクションブロックに入れることで、 TX のブロードキャストに失敗したときに UTXO ロックもロールバックされるようにする。

## 2. 単体で funding TX の作成とブロードキャストをする #add_utxo_to! と #add_p2c_utxo_to! は 1. のトランザクションブロックに入れない。

`#add_utxo_to!` と `#add_p2c_utxo_to!` は内部で funding TX をブロードキャストする。このブロードキャストが成功したことを前提として、実際のコントラクト用の TX が構成される。これらを１つのDBトランザクションに入れてしまうと、funding TX のブロードキャストに成功した後に、コントラクト TX のブロードキャストに失敗した場合にDBがロールバックされ、funding TX の入力として消費した UTXO が復活し、出力の UTXO が消えてしまう。これによりオンチェーンの状態と DB の UTXO の状態の同期が壊れてしまう。

##  3. TX のブロードキャスト処理は、トランザクションブロック内のDB操作の一番最後に記述する。

TXのブロードキャスト処理の後に、TX のブロードキャストの成否と不可分なDB操作を行うと次の問題が発生する。TX のブロードキャストに成功した後に DB に関連するデータを挿入しようとしたとする。しかしその挿入が失敗した場合に、DB トランザクションがロールバックされる。これには DB で管理している UTXO の状態も含まれる。しかしオンチェーンの状態は TX のブロードキャストの成功により更新され巻き戻すことはできない。これによりDB の UTXO の状態とオンチェーンの状態の同期が壊れる。

## 4. TX のブロードキャスト処理を含むDBトランザクションは、トランザクション分離レベルを READ COMMITTED にする。

MySQL InnoDB のデフォルトのトランザクション分離レベルである `REPEATABLE READ` ではブロードキャストする TX の出力の UTXO をDBに挿入する処理においてデッドロックが発生する可能性がある。これを回避するために `READ COMMITTED` とする必要がある。