### PR TITLE
Add funcitonality tests for timestamp

### DIFF
--- a/lib/glueby/internal/contract_builder.rb
+++ b/lib/glueby/internal/contract_builder.rb
@@ -130,7 +130,7 @@ module Glueby
       )
         tx, index = nil
 
-        ActiveRecord::Base.transaction(joinable: false, requires_new: true) do
+        Glueby::AR.transaction(isolation: :read_committed) do
           if Glueby.configuration.use_utxo_provider? || utxo_provider
             utxo_provider ||= UtxoProvider.new
             script_pubkey = Tapyrus::Script.parse_from_addr(address)

--- a/spec/functional/timestamp_spec.rb
+++ b/spec/functional/timestamp_spec.rb
@@ -1,297 +1,403 @@
-RSpec.describe 'Timestamp Contract', functional: true do
-  context 'use activerecord wallet adapter', active_record: true do
-    before do
-      Glueby.configuration.wallet_adapter = :activerecord
-      Glueby::BlockSyncer.register_syncer(Glueby::Contract::Timestamp::Syncer)
+RSpec.describe 'Timestamp Contract', functional: true, mysql: true do
+  before do
+    Glueby::BlockSyncer.register_syncer(Glueby::Contract::Timestamp::Syncer)
+  end
+
+  after do
+    Glueby::BlockSyncer.unregister_syncer(Glueby::Contract::Timestamp::Syncer)
+  end
+
+  shared_examples 'unlock UTXOs if the timestamp txs are not broadcasted' do
+    subject { timestamp.save! }
+    let(:utxo_provider) { Glueby::UtxoProvider.new }
+    let(:sender) { Glueby::Wallet.create }
+    let(:rpc) { double('mock') }
+    let(:timestamp_type) { :simple }
+    let(:timestamp) do
+      Glueby::Contract::Timestamp.new(
+        wallet: sender,
+        content: "\xFF\xFF\xFF",
+        prefix: 'app',
+        timestamp_type: timestamp_type,
+        utxo_provider: utxo_provider,
+        hex: true
+      )
     end
 
-    after do
-      Glueby::Internal::Wallet.wallet_adapter = nil
-      Glueby::BlockSyncer.unregister_syncer(Glueby::Contract::Timestamp::Syncer)
+    context 'broadcasting funding tx is failure' do
+      before do
+        allow(Glueby::Internal::RPC).to receive(:client).and_return(rpc)
+        allow(rpc).to receive(:sendrawtransaction).and_raise(Tapyrus::RPC::Error.new(
+          '500',
+          'Internal Server Error',
+          { 'code' => -25, 'message' => 'Missing inputs'}))
+      end
+
+      it 'doesn\'t create unlocked UTXOs' do
+        expect { subject }.to raise_error(Glueby::Contract::Errors::FailedToBroadcast)
+        expect(Glueby::Internal::Wallet::AR::Utxo.where('locked_at is not null').count).to eq 0
+      end
     end
 
-    context 'trackable type' do
-      context 'bear fees by sender' do
-        let(:fee) { 10_000 }
-        let(:fee_estimator) { Glueby::Contract::FeeEstimator::Fixed.new(fixed_fee: fee) }
-        let(:sender) { Glueby::Wallet.create }
-        let(:before_balance) { sender.balances(false)[''] }
+    context 'broadcasting timestamp tx is failure' do
+      before do
+        allow(Glueby::Internal::RPC).to receive(:client).and_return(rpc)
 
-        before do
-          process_block(to_address: sender.internal_wallet.receive_address)
-          before_balance
-        end
+        call_count = 0
+        allow(rpc).to receive(:sendrawtransaction) do |tx|
+          if call_count == 0
+            Tapyrus::Tx.parse_from_payload(tx.htb).txid
+          elsif call_count == 1
+            raise Tapyrus::RPC::Error.new(
+              '500',
+              'Internal Server Error',
+              { 'code' => -25, 'message' => 'Missing inputs'})
+          end
 
-        it 'use rake task' do
-          # Add timestamp job to timestamps table
-          ar = Glueby::Contract::AR::Timestamp.create(wallet_id: sender.id, content: "\xFF\xFF\xFF", prefix: 'app', timestamp_type: :trackable)
-          expect(ar.status).to eq('init')
-          expect(ar.txid).to be_nil
-          expect(ar.p2c_address).to be_nil
-          expect(ar.payment_base).to be_nil
-
-          # Broadcast tx for the timestamp job
-          Rake.application['glueby:contract:timestamp:create'].execute
-          ar.reload
-          expect(sender.balances(false)['']).to eq(before_balance - Glueby::Contract::Timestamp::P2C_DEFAULT_VALUE - fee)
-          expect(ar.status).to eq('unconfirmed')
-          expect(ar.txid).not_to be_nil
-          expect(ar.p2c_address).not_to be_nil
-          expect(ar.payment_base).not_to be_nil
-
-
-          # Sync blocks, but the status is still unconfirmed because a new block is not created.
-          Rake.application['glueby:block_syncer:start'].execute
-          ar.reload
-          expect(ar.status).to eq('unconfirmed')
-
-          process_block
-
-          # Sync blocks, then the status is changed to confirmed because of generating a block.
-          Rake.application['glueby:block_syncer:start'].execute
-          ar.reload
-          expect(ar.status).to eq('confirmed')
+          call_count += 1
         end
       end
 
-      context 'UtxoProvider provides UTXOs' do
-        include_context 'setup utxo provider'
+      it 'doesn\'t create unlocked UTXOs' do
+        expect { subject }.to raise_error(Glueby::Contract::Errors::FailedToBroadcast)
+        expect(Glueby::Internal::Wallet::AR::Utxo.where('locked_at is not null').count).to eq 0
+      end
+    end
+  end
 
+  context 'trackable type' do
+    context 'bear fees by sender' do
+      let(:fee) { 10_000 }
+      let(:fee_estimator) { Glueby::Contract::FeeEstimator::Fixed.new(fixed_fee: fee) }
+      let(:sender) { Glueby::Wallet.create }
+      let(:before_balance) { sender.balances(false)[''] }
+
+      before do
+        process_block(to_address: sender.internal_wallet.receive_address)
+        before_balance
+      end
+
+      it 'use rake task' do
+        # Add timestamp job to timestamps table
+        ar = Glueby::Contract::AR::Timestamp.create(wallet_id: sender.id, content: "\xFF\xFF\xFF", prefix: 'app', timestamp_type: :trackable)
+        expect(ar.status).to eq('init')
+        expect(ar.txid).to be_nil
+        expect(ar.p2c_address).to be_nil
+        expect(ar.payment_base).to be_nil
+
+        # Broadcast tx for the timestamp job
+        Rake.application['glueby:contract:timestamp:create'].execute
+        ar.reload
+        expect(sender.balances(false)['']).to eq(before_balance - Glueby::Contract::Timestamp::P2C_DEFAULT_VALUE - fee)
+        expect(ar.status).to eq('unconfirmed')
+        expect(ar.txid).not_to be_nil
+        expect(ar.p2c_address).not_to be_nil
+        expect(ar.payment_base).not_to be_nil
+
+
+        # Sync blocks, but the status is still unconfirmed because a new block is not created.
+        Rake.application['glueby:block_syncer:start'].execute
+        ar.reload
+        expect(ar.status).to eq('unconfirmed')
+
+        process_block
+
+        # Sync blocks, then the status is changed to confirmed because of generating a block.
+        Rake.application['glueby:block_syncer:start'].execute
+        ar.reload
+        expect(ar.status).to eq('confirmed')
+      end
+    end
+
+    context 'UtxoProvider provides UTXOs' do
+      include_context 'setup utxo provider'
+
+      let(:sender) { Glueby::Wallet.create }
+      let(:utxo_provider) { Glueby::UtxoProvider.new }
+
+      it do
+        # Add timestamp job to timestamps table
+        ar = Glueby::Contract::AR::Timestamp.create(wallet_id: sender.id, content: "\xFF\xFF\xFF", prefix: 'app', timestamp_type: :trackable)
+        expect(ar.status).to eq('init')
+        expect(ar.txid).to be_nil
+        expect(ar.p2c_address).to be_nil
+        expect(ar.payment_base).to be_nil
+
+        # Broadcast tx for the timestamp job
+        # and it should consume two UTXOs in UtxoProvider
+        # It creates two TXs, the one is funding tx that is created by UTXO Provider to provide a tapyrus input
+        # to the timestamp tx. The funding tx has two inputs from UTXO pool and the input amount is 8000 tapyrus.
+        # The timestamp TX requires 3000 tapyrus, so the funding tx has 4000 tapyrus output to the timestamp tx.
+        # The fee of the funding tx is 2000 tapyrus, this is fixed by FixedFeeEstimator. And the change is 3000
+        # tapyrus to the UTXO Provider's wallet. So, it should consume two UTXOs from UTXO Provider.
+        expect do
+          Rake.application['glueby:contract:timestamp:create'].execute
+        end.to change { utxo_provider.wallet.list_unspent.count }.by(-2)
+
+        ar.reload
+        expect(sender.balances(false)['']).to be_nil
+        expect(ar.status).to eq('unconfirmed')
+        expect(ar.txid).not_to be_nil
+        expect(ar.p2c_address).not_to be_nil
+        expect(ar.payment_base).not_to be_nil
+
+        # Sync blocks, but the status is still unconfirmed because a new block is not created.
+        Rake.application['glueby:block_syncer:start'].execute
+        ar.reload
+        expect(ar.status).to eq('unconfirmed')
+
+        process_block
+
+        # Sync blocks, then the status is changed to confirmed because of generating a block.
+        Rake.application['glueby:block_syncer:start'].execute
+        ar.reload
+        expect(ar.status).to eq('confirmed')
+
+        # Update the timestamp
+        update_ar = Glueby::Contract::AR::Timestamp.create(
+          wallet_id: sender.id,
+          content: "1234".htb,
+          prefix: 'app',
+          timestamp_type: :trackable,
+          prev_id: ar.id
+        )
+        expect do
+          Rake.application['glueby:contract:timestamp:create'].execute
+        end.to change { utxo_provider.wallet.list_unspent.count }.by(-2)
+
+        update_ar.reload
+        # expect(sender.balances(false)['']).to be_nil
+        expect(update_ar.status).to eq('unconfirmed')
+        expect(update_ar.txid).not_to be_nil
+        expect(update_ar.p2c_address).not_to be_nil
+        expect(update_ar.payment_base).not_to be_nil
+
+        process_block
+
+        # Sync blocks, then the status is changed to confirmed because of generating a block.
+        Rake.application['glueby:block_syncer:start'].execute
+        update_ar.reload
+        expect(update_ar.status).to eq('confirmed')
+
+        # Try to update already updated timestamp
+        timestamp = Glueby::Contract::AR::Timestamp.new(
+          wallet_id: sender.id,
+          content: "1234".htb,
+          prefix: 'app',
+          timestamp_type: :trackable,
+          prev_id: ar.id
+        )
+        expect { timestamp.save_with_broadcast! }
+          .to raise_error(
+            Glueby::Contract::Errors::PrevTimestampAlreadyUpdated,
+            /The previous timestamp\(id: [0-9]+\) was already updated/
+          )
+          .and change { utxo_provider.wallet.list_unspent.count }.by(0) # never consume UTXO pool and never broadcast any tx.
+      end
+      
+      context 'work well under multi-threads' do
+        let(:utxo_pool_size) { 80 }
+        let(:fee_estimator_for_manage) { Glueby::Contract::FeeEstimator::Auto.new }
         let(:sender) { Glueby::Wallet.create }
-        let(:utxo_provider) { Glueby::UtxoProvider.new }
 
-        it do
-          # Add timestamp job to timestamps table
-          ar = Glueby::Contract::AR::Timestamp.create(wallet_id: sender.id, content: "\xFF\xFF\xFF", prefix: 'app', timestamp_type: :trackable)
-          expect(ar.status).to eq('init')
-          expect(ar.txid).to be_nil
-          expect(ar.p2c_address).to be_nil
-          expect(ar.payment_base).to be_nil
-
-          # Broadcast tx for the timestamp job
-          # and it should consume two UTXOs in UtxoProvider
-          # It creates two TXs, the one is funding tx that is created by UTXO Provider to provide a tapyrus input
-          # to the timestamp tx. The funding tx has two inputs from UTXO pool and the input amount is 8000 tapyrus.
-          # The timestamp TX requires 3000 tapyrus, so the funding tx has 4000 tapyrus output to the timestamp tx.
-          # The fee of the funding tx is 2000 tapyrus, this is fixed by FixedFeeEstimator. And the change is 3000
-          # tapyrus to the UTXO Provider's wallet. So, it should consume two UTXOs from UTXO Provider.
-          expect do
-            Rake.application['glueby:contract:timestamp:create'].execute
-          end.to change { utxo_provider.wallet.list_unspent.count }.by(-2)
-
-          ar.reload
-          expect(sender.balances(false)['']).to be_nil
-          expect(ar.status).to eq('unconfirmed')
-          expect(ar.txid).not_to be_nil
-          expect(ar.p2c_address).not_to be_nil
-          expect(ar.payment_base).not_to be_nil
-
-          # Sync blocks, but the status is still unconfirmed because a new block is not created.
-          Rake.application['glueby:block_syncer:start'].execute
-          ar.reload
-          expect(ar.status).to eq('unconfirmed')
-
-          process_block
-
-          # Sync blocks, then the status is changed to confirmed because of generating a block.
-          Rake.application['glueby:block_syncer:start'].execute
-          ar.reload
-          expect(ar.status).to eq('confirmed')
-
-          # Update the timestamp
-          update_ar = Glueby::Contract::AR::Timestamp.create(
-            wallet_id: sender.id,
-            content: "1234".htb,
-            prefix: 'app',
-            timestamp_type: :trackable,
-            prev_id: ar.id
-          )
-          expect do
-            Rake.application['glueby:contract:timestamp:create'].execute
-          end.to change { utxo_provider.wallet.list_unspent.count }.by(-2)
-
-          update_ar.reload
-          # expect(sender.balances(false)['']).to be_nil
-          expect(update_ar.status).to eq('unconfirmed')
-          expect(update_ar.txid).not_to be_nil
-          expect(update_ar.p2c_address).not_to be_nil
-          expect(update_ar.payment_base).not_to be_nil
-
-          process_block
-
-          # Sync blocks, then the status is changed to confirmed because of generating a block.
-          Rake.application['glueby:block_syncer:start'].execute
-          update_ar.reload
-          expect(update_ar.status).to eq('confirmed')
-
-          # Try to update already updated timestamp
-          timestamp = Glueby::Contract::AR::Timestamp.new(
-            wallet_id: sender.id,
-            content: "1234".htb,
-            prefix: 'app',
-            timestamp_type: :trackable,
-            prev_id: ar.id
-          )
-          expect { timestamp.save_with_broadcast! }
-            .to raise_error(
-              Glueby::Contract::Errors::PrevTimestampAlreadyUpdated,
-              /The previous timestamp\(id: [0-9]+\) was already updated/
+        it 'broadcast transactions with no error on multi thread' do
+          on_multi_thread(20) do
+            timestamp = Glueby::Contract::AR::Timestamp.new(
+              wallet_id: sender.id,
+              content: 'ffffff',
+              prefix: 'aabb',
+              timestamp_type: :trackable
             )
-            .and change { utxo_provider.wallet.list_unspent.count }.by(0) # never consume UTXO pool and never broadcast any tx.
+
+            timestamp.save_with_broadcast!
+
+            Glueby::Contract::AR::Timestamp.new(
+              wallet_id: sender.id,
+              content: "eeeeee",
+              prefix: 'aabb',
+              timestamp_type: :trackable,
+              prev_id: timestamp.id
+            ).save_with_broadcast!
+          end
         end
+      end
+
+      it_behaves_like 'unlock UTXOs if the timestamp txs are not broadcasted'
+    end
+  end
+
+  context 'simple type' do
+    context 'bear fees by sender' do
+      let(:fee) { 10_000 }
+      let(:fee_estimator) { Glueby::Contract::FeeEstimator::Fixed.new(fixed_fee: fee) }
+      let(:sender) { Glueby::Wallet.create }
+      let(:before_balance) { sender.balances(false)[''] }
+
+      before do
+        process_block(to_address: sender.internal_wallet.receive_address)
+        before_balance
+      end
+
+      it 'use Glueby::Contract::Timestamp directly' do
+        timestamp = Glueby::Contract::Timestamp.new(
+          wallet: sender,
+          content: "\xFF\xFF\xFF",
+          prefix: 'app',
+          fee_estimator: fee_estimator
+        )
+        timestamp.save!
+
+        expect(sender.balances(false)['']).to eq(before_balance - fee)
+      end
+
+      it 'use rake task' do
+        # Add timestamp job to timestamps table
+        ar = Glueby::Contract::AR::Timestamp.create(wallet_id: sender.id, content: "\xFF\xFF\xFF", prefix: 'app')
+        expect(ar.status).to eq('init')
+        expect(ar.txid).to be_nil
+
+        # Broadcast tx for the timestamp job
+        Rake.application['glueby:contract:timestamp:create'].execute
+        ar.reload
+        expect(sender.balances(false)['']).to eq(before_balance - fee)
+        expect(ar.status).to eq('unconfirmed')
+        expect(ar.txid).not_to be_nil
+
+        # Sync blocks, but the status is still unconfirmed because a new block is not created.
+        Rake.application['glueby:block_syncer:start'].execute
+        ar.reload
+        expect(ar.status).to eq('unconfirmed')
+
+        process_block
+
+        # Sync blocks, then the status is changed to confirmed because of generating a block.
+        Rake.application['glueby:block_syncer:start'].execute
+        ar.reload
+        expect(ar.status).to eq('confirmed')
       end
     end
 
-    context 'simple type' do
-      context 'bear fees by sender' do
-        let(:fee) { 10_000 }
-        let(:fee_estimator) { Glueby::Contract::FeeEstimator::Fixed.new(fixed_fee: fee) }
-        let(:sender) { Glueby::Wallet.create }
-        let(:before_balance) { sender.balances(false)[''] }
+    context 'bear fees by FeeProvider' do
+      include_context 'setup fee provider'
 
-        before do
-          process_block(to_address: sender.internal_wallet.receive_address)
-          before_balance
-        end
+      let(:fee) { 10_000 }
+      let(:fee_estimator) { Glueby::Contract::FeeEstimator::Fixed.new(fixed_fee: fee) }
+      let(:sender) { Glueby::Wallet.create }
+      let(:before_balance) { sender.balances(false)[''] }
 
-        it 'use Glueby::Contract::Timestamp directly' do
-          timestamp = Glueby::Contract::Timestamp.new(
-            wallet: sender,
-            content: "\xFF\xFF\xFF",
-            prefix: 'app',
-            fee_estimator: fee_estimator
-          )
-          timestamp.save!
-
-          expect(sender.balances(false)['']).to eq(before_balance - fee)
-        end
-
-        it 'use rake task' do
-          # Add timestamp job to timestamps table
-          ar = Glueby::Contract::AR::Timestamp.create(wallet_id: sender.id, content: "\xFF\xFF\xFF", prefix: 'app')
-          expect(ar.status).to eq('init')
-          expect(ar.txid).to be_nil
-
-          # Broadcast tx for the timestamp job
-          Rake.application['glueby:contract:timestamp:create'].execute
-          ar.reload
-          expect(sender.balances(false)['']).to eq(before_balance - fee)
-          expect(ar.status).to eq('unconfirmed')
-          expect(ar.txid).not_to be_nil
-
-          # Sync blocks, but the status is still unconfirmed because a new block is not created.
-          Rake.application['glueby:block_syncer:start'].execute
-          ar.reload
-          expect(ar.status).to eq('unconfirmed')
-
-          process_block
-
-          # Sync blocks, then the status is changed to confirmed because of generating a block.
-          Rake.application['glueby:block_syncer:start'].execute
-          ar.reload
-          expect(ar.status).to eq('confirmed')
-        end
+      before do
+        process_block(to_address: sender.internal_wallet.receive_address)
+        before_balance
       end
 
-      context 'bear fees by FeeProvider' do
-        include_context 'setup fee provider'
+      it 'use Glueby::Contract::Timestamp directly' do
+        timestamp = Glueby::Contract::Timestamp.new(
+          wallet: sender,
+          content: "\xFF\xFF\xFF",
+          prefix: 'app',
+          fee_estimator: fee_estimator
+        )
+        timestamp.save!
 
-        let(:fee) { 10_000 }
-        let(:fee_estimator) { Glueby::Contract::FeeEstimator::Fixed.new(fixed_fee: fee) }
-        let(:sender) { Glueby::Wallet.create }
-        let(:before_balance) { sender.balances(false)[''] }
-
-        before do
-          process_block(to_address: sender.internal_wallet.receive_address)
-          before_balance
-        end
-
-        it 'use Glueby::Contract::Timestamp directly' do
-          timestamp = Glueby::Contract::Timestamp.new(
-            wallet: sender,
-            content: "\xFF\xFF\xFF",
-            prefix: 'app',
-            fee_estimator: fee_estimator
-          )
-          timestamp.save!
-
-          expect(sender.balances(false)['']).to eq(before_balance)
-        end
-
-        it 'use rake task' do
-          # Add timestamp job to timestamps table
-          ar = Glueby::Contract::AR::Timestamp.create(wallet_id: sender.id, content: "\xFF\xFF\xFF", prefix: 'app')
-          expect(ar.status).to eq('init')
-          expect(ar.txid).to be_nil
-
-          # Broadcast tx for the timestamp job
-          Rake.application['glueby:contract:timestamp:create'].execute
-          ar.reload
-          expect(sender.balances(false)['']).to eq(before_balance)
-          expect(ar.status).to eq('unconfirmed')
-          expect(ar.txid).not_to be_nil
-
-          # Sync blocks, but the status is still unconfirmed because a new block is not created.
-          Rake.application['glueby:block_syncer:start'].execute
-          ar.reload
-          expect(ar.status).to eq('unconfirmed')
-
-          process_block
-
-          # Sync blocks, then the status is changed to confirmed because of generating a block.
-          Rake.application['glueby:block_syncer:start'].execute
-          ar.reload
-          expect(ar.status).to eq('confirmed')
-        end
+        expect(sender.balances(false)['']).to eq(before_balance)
       end
 
-      context 'UtxoProvider provides UTXOs' do
-        include_context 'setup utxo provider'
+      it 'use rake task' do
+        # Add timestamp job to timestamps table
+        ar = Glueby::Contract::AR::Timestamp.create(wallet_id: sender.id, content: "\xFF\xFF\xFF", prefix: 'app')
+        expect(ar.status).to eq('init')
+        expect(ar.txid).to be_nil
 
-        let(:sender) { Glueby::Wallet.create }
+        # Broadcast tx for the timestamp job
+        Rake.application['glueby:contract:timestamp:create'].execute
+        ar.reload
+        expect(sender.balances(false)['']).to eq(before_balance)
+        expect(ar.status).to eq('unconfirmed')
+        expect(ar.txid).not_to be_nil
+
+        # Sync blocks, but the status is still unconfirmed because a new block is not created.
+        Rake.application['glueby:block_syncer:start'].execute
+        ar.reload
+        expect(ar.status).to eq('unconfirmed')
+
+        process_block
+
+        # Sync blocks, then the status is changed to confirmed because of generating a block.
+        Rake.application['glueby:block_syncer:start'].execute
+        ar.reload
+        expect(ar.status).to eq('confirmed')
+      end
+    end
+
+    context 'UtxoProvider provides UTXOs' do
+      include_context 'setup utxo provider'
+
+      let(:sender) { Glueby::Wallet.create }
+      let(:utxo_provider) { Glueby::UtxoProvider.new }
+
+      it 'use Glueby::Contract::Timestamp directly' do
+        timestamp = Glueby::Contract::Timestamp.new(
+          wallet: sender,
+          content: "\xFF\xFF\xFF",
+          prefix: 'app',
+          utxo_provider: utxo_provider
+        )
+        timestamp.save!
+
+        expect(sender.balances(false)['']).to be_nil
+      end
+
+      it 'use rake task' do
+        # Add timestamp job to timestamps table
+        ar = Glueby::Contract::AR::Timestamp.create(wallet_id: sender.id, content: "\xFF\xFF\xFF", prefix: 'app')
+        expect(ar.status).to eq('init')
+        expect(ar.txid).to be_nil
+
+        # Broadcast tx for the timestamp job
+        # and it should consume one UTXO in UtxoProvider
+        expect do
+          Rake.application['glueby:contract:timestamp:create'].execute
+        end.to change { utxo_provider.wallet.list_unspent.count }.by(-1)
+        ar.reload
+        expect(sender.balances(false)['']).to be_nil
+        expect(ar.status).to eq('unconfirmed')
+        expect(ar.txid).not_to be_nil
+
+        # Sync blocks, but the status is still unconfirmed because a new block is not created.
+        Rake.application['glueby:block_syncer:start'].execute
+        ar.reload
+        expect(ar.status).to eq('unconfirmed')
+
+        process_block
+
+        # Sync blocks, then the status is changed to confirmed because of generating a block.
+        Rake.application['glueby:block_syncer:start'].execute
+        ar.reload
+        expect(ar.status).to eq('confirmed')
+      end
+
+      context 'work well under multi-threads' do
+        let(:utxo_pool_size) { 40 }
+        let(:fee_estimator_for_manage) { Glueby::Contract::FeeEstimator::Auto.new }
         let(:utxo_provider) { Glueby::UtxoProvider.new }
+        let(:sender) { Glueby::Wallet.create }
 
-        it 'use Glueby::Contract::Timestamp directly' do
-          timestamp = Glueby::Contract::Timestamp.new(
-            wallet: sender,
-            content: "\xFF\xFF\xFF",
-            prefix: 'app',
-            utxo_provider: utxo_provider
-          )
-          timestamp.save!
+        let(:timestamp_type) { :simple }
 
-          expect(sender.balances(false)['']).to be_nil
-        end
-
-        it 'use rake task' do
-          # Add timestamp job to timestamps table
-          ar = Glueby::Contract::AR::Timestamp.create(wallet_id: sender.id, content: "\xFF\xFF\xFF", prefix: 'app')
-          expect(ar.status).to eq('init')
-          expect(ar.txid).to be_nil
-
-          # Broadcast tx for the timestamp job
-          # and it should consume one UTXO in UtxoProvider
-          expect do
-            Rake.application['glueby:contract:timestamp:create'].execute
-          end.to change { utxo_provider.wallet.list_unspent.count }.by(-1)
-          ar.reload
-          expect(sender.balances(false)['']).to be_nil
-          expect(ar.status).to eq('unconfirmed')
-          expect(ar.txid).not_to be_nil
-
-          # Sync blocks, but the status is still unconfirmed because a new block is not created.
-          Rake.application['glueby:block_syncer:start'].execute
-          ar.reload
-          expect(ar.status).to eq('unconfirmed')
-
-          process_block
-
-          # Sync blocks, then the status is changed to confirmed because of generating a block.
-          Rake.application['glueby:block_syncer:start'].execute
-          ar.reload
-          expect(ar.status).to eq('confirmed')
+        it 'broadcast transactions with no error on multi thread' do
+          on_multi_thread(20) do
+            Glueby::Contract::Timestamp.new(
+              wallet: sender,
+              content: "\xFF\xFF\xFF",
+              prefix: 'app',
+              timestamp_type: timestamp_type,
+              utxo_provider: utxo_provider
+            ).save!
+          end
         end
       end
+
+      it_behaves_like 'unlock UTXOs if the timestamp txs are not broadcasted'
     end
   end
 end

--- a/spec/support/setup_utxo_provider.rb
+++ b/spec/support/setup_utxo_provider.rb
@@ -4,6 +4,7 @@ RSpec.shared_context 'setup utxo provider' do
   let(:default_fixed_fee) { 2_000 }
   let(:default_value) { 4_000 }
   let(:utxo_pool_size) { 20 }
+  let(:fee_estimator_for_manage) { nil }
 
   before do
     Glueby::Contract::FeeEstimator::Fixed.default_fixed_fee = default_fixed_fee
@@ -11,7 +12,8 @@ RSpec.shared_context 'setup utxo provider' do
       config.enable_utxo_provider!
       config.utxo_provider_config = {
         default_value: default_value,
-        utxo_pool_size: utxo_pool_size
+        utxo_pool_size: utxo_pool_size,
+        fee_estimator_for_manage: fee_estimator_for_manage
       }
     end
     # create UTXOs in the UTXO pool


### PR DESCRIPTION
resolves #184

Timestamp を複数スレッドで作成するケースとTXのブロードキャストで失敗するケースのテストを追加しました。

Token コントラクトで発生したような TX のブロードキャスト失敗時に UTXO がロックされたままになる挙動や、複数スレッドで操作したときにデッドロックが発生する挙動はありませんでした。

前者については token コントラクトの対応で行った `ContractBuilder#add_utxo_to!` のDBトランザクションブロックの見直しが影響して発生しなかったものと思われます。

後者については、 Timestamp コントラクトの TX の UTXO は `timestamp_type: trackable` については glueby_utxos テーブルでは管理されないし、`timestamp_type: simple` については OP_RETURN アウトプットが１つ作られるだけで、 token コントラクトのときに問題になった glueby_utxos テーブルへの挿入時のデッドロックが発生する要素がなかったためだと思われます。

