### PR TITLE
Move coverage threshold to spec_helper

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,11 +7,8 @@
 
 name: Ruby
 
-on:
-  push:
-    branches: [master, v1.1, v1.2]
-  pull_request:
-    branches: [master, v1.1, v1.2]
+on: [push,pull_request]
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,9 +31,3 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Run tests
         run: bundle exec rake
-      - name: SimpleCov+ Action
-        uses: joshmfrankel/simplecov-check-action@main
-        with:
-          minimum_suite_coverage: 99
-          minimum_file_coverage: 70
-          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ TAPYRUSD_VERSION = 'v0.5.2'
 SimpleCov.start do
   add_filter '/spec/'
   SimpleCov.minimum_coverage 99
+  SimpleCov.minimum_coverage_by_file 70
 end
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ TAPYRUSD_VERSION = 'v0.5.2'
 
 SimpleCov.start do
   add_filter '/spec/'
+  SimpleCov.minimum_coverage 99
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
By setting the coverage threshold in the SimpleCov settings in spec_helper, the coverage threshold will also be checked after the test run. This allows coverage checking to work even if you create a PR from a forked repository.

Also, I don't think it's necessary to specify the PR execution branch, so I've removed the branch specification.