### PR TITLE
Fix ci error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
-gem "docker-api", "~> 2.1.0"
+gem "docker-api", "~> 2.4.0"
 
 gem "simplecov", require: false

--- a/spec/functional/token_spec.rb
+++ b/spec/functional/token_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Token Contract', functional: true, mysql: true do
             amount: 10_000,
             fee_estimator: fee_estimator
           )
-        rescue Errno::ECONNREFUSED
+        rescue Errno::ECONNREFUSED, Errno::ECONNRESET
           # Ignored
         end
         expect(Glueby::Contract::AR::ReissuableToken.count).to eq(1)


### PR DESCRIPTION
Change the following to fix the CI error:

* Fix an inconsistency issue with `docker-api` caused by `excon` gem update
* Fix error due to changes in thrown exception(probably due to excon update)
* Fix DB related error(following) in functional tests that only occurred in CI environment


```
52) Token Contract multi threading NFT token behaves like burning token works correctly broadcasting is failure unlock UTXOs that are used as inputs
      Failure/Error:
        connection.create_table :glueby_wallets do |t|
          t.string :wallet_id
          t.timestamps
        end

      ActiveRecord::ConnectionNotEstablished:
        Lost connection to MySQL server at 'reading initial communication packet', system error: 0
      Shared Example Group: "burning token works correctly" called from ./spec/functional/token_spec.rb:706
      # ./vendor/bundle/ruby/3.1.0/gems/activerecord-7.2.2.1/lib/active_record/connection_adapters/mysql2_adapter.rb:35:in `rescue in new_client'
      # ./vendor/bundle/ruby/3.1.0/gems/activerecord-7.2.2.1/lib/active_record/connection_adapters/mysql/schema_statements.rb:86:in `create_table'
...
      # ./spec/spec_helper.rb:95:in `setup_database'
      # ./spec/spec_helper.rb:46:in `block (2 levels) in <top (required)>'
      # ------------------
      # --- Caused by: ---
      # Mysql2::Error::ConnectionError:
      #   Lost connection to MySQL server at 'reading initial communication packet', system error: 0
      #   ./vendor/bundle/ruby/3.1.0/gems/mysql2-0.5.6/lib/mysql2/client.rb:97:in `connect'

```