### PR TITLE
Add wallet_id argument to the Glueby::Wallet#create

### DIFF
--- a/lib/glueby/wallet.rb
+++ b/lib/glueby/wallet.rb
@@ -5,8 +5,8 @@ module Glueby
     attr_reader :internal_wallet
 
     class << self
-      def create
-        new(Glueby::Internal::Wallet.create)
+      def create(wallet_id = nil)
+        new(Glueby::Internal::Wallet.create(wallet_id))
       end
 
       def load(wallet_id)

--- a/spec/glueby/wallet_spec.rb
+++ b/spec/glueby/wallet_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe 'Glueby::Wallet' do
   class TestWalletAdapter < Glueby::Internal::Wallet::AbstractWalletAdapter
     def create_wallet(wallet_id = nil)
-      "wallet_id:1"
+      wallet_id ? wallet_id : "wallet_id:1"
     end
     def list_unspent(wallet_id, only_finalized = true, label = nil, color_id: nil)
       utxos = [
@@ -109,6 +109,23 @@ RSpec.describe 'Glueby::Wallet' do
     context 'unsupported adapter' do
       let(:adapter) { 'unknown' }
       it { expect { subject }.to raise_error(RuntimeError, 'Not implemented') }
+    end
+  end
+
+  describe '#create' do
+    subject { Glueby::Wallet.create }
+
+    it 'returns Glueby::Wallet instance' do
+      expect(subject).to be_a Glueby::Wallet
+    end
+
+    context 'with wallet_id' do
+      let(:wallet_id) { 'wallet_id' }
+      subject { Glueby::Wallet.create(wallet_id) }
+
+      it 'created wallet has specified wallet_id' do
+        expect(subject.id).to eq(wallet_id)
+      end
     end
   end
 


### PR DESCRIPTION
アプリケーション内部で扱うアセットのライフサイクルを管理するための特別なウォレットを作りたい。これにランダムなwallet id ではなく固定の wallet id を与えることでロードを簡単にでき扱いやすくしたいです。