### PR TITLE
Add Token.import_reissuable_token_script_pubkey

### DIFF
--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -89,7 +89,6 @@ module Glueby
         # Creates AR::ReissuableToken record if it is not created before.
         #
         # @param [Tapyrus::Script] script_pubkey - The script pubkey that is used to issue the reissuable token
-        # @return [nil]
         # @raise [Glueby::ArgumentError] If the script_pubkey is not an instance of Tapyrus::Script
         def import_reissuable_token_script_pubkey(script_pubkey)
           raise Glueby::ArgumentError, 'script_pubkey should be a Tapyrus::Script' unless script_pubkey.is_a?(Tapyrus::Script)

--- a/lib/glueby/contract/token.rb
+++ b/lib/glueby/contract/token.rb
@@ -86,6 +86,19 @@ module Glueby
           Glueby::AR::SystemInformation.use_only_finalized_utxo?
         end
 
+        # Creates AR::ReissuableToken record if it is not created before.
+        #
+        # @param [Tapyrus::Script] script_pubkey - The script pubkey that is used to issue the reissuable token
+        # @return [nil]
+        # @raise [Glueby::ArgumentError] If the script_pubkey is not an instance of Tapyrus::Script
+        def import_reissuable_token_script_pubkey(script_pubkey)
+          raise Glueby::ArgumentError, 'script_pubkey should be a Tapyrus::Script' unless script_pubkey.is_a?(Tapyrus::Script)
+
+          color_id = Tapyrus::Color::ColorIdentifier.reissuable(script_pubkey)
+          Glueby::Contract::AR::ReissuableToken.find_or_create_by!(color_id: color_id.to_hex, script_pubkey: script_pubkey.to_hex)
+          nil
+        end
+
         private
 
         def issue_reissuable_token(issuer:, amount:, split: 1, fee_estimator:, metadata: nil)


### PR DESCRIPTION
外部で発行された再発行可能トークンをインポートして扱うためのメソッドを追加しました。
追加したメソッドで、Glueby::Contract::AR::ReissuableTokenのレコードが作られることで、#reissue! が機能するようになります。

すでに #parse_from_payload で同様のことができますが、#to_payload で出力された値を前提とするため、glueby 以外で発行された再発行可能トークンのインポートとしては扱いにくいため、新しいインターフェースを追加します。